### PR TITLE
Prep for alb logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@ All notable changes to this project will be documented in this file.
 
 <a name="unreleased"></a>
 ## [Unreleased]
-- Added: ALB logging - both ALBs log to the same bucket, using their own prefixs - api and push
 - Updated: Upgraded AWS provider from = 2.68.0 to ~> 2.70.0
 - Updated: Switched to using templatefile function rather than deprecated template provider
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 <a name="unreleased"></a>
 ## [Unreleased]
+- Added: ALB logging - both ALBs log to the same bucket, using their own prefixs - api and push
 - Updated: Upgraded AWS provider from = 2.68.0 to ~> 2.70.0
 - Updated: Switched to using templatefile function rather than deprecated template provider
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 <a name="unreleased"></a>
 ## [Unreleased]
+- Updated: Upgraded AWS provider from = 2.68.0 to ~> 2.70.0
+- Updated: Switched to using templatefile function rather than deprecated template provider
+
 
 <a name="v0.1.1"></a>
 ## [v0.1.1] 2020-08-13

--- a/alb.tf
+++ b/alb.tf
@@ -31,12 +31,6 @@ resource "aws_lb" "api" {
   enable_deletion_protection       = true
 
   tags = module.labels.tags
-
-  access_logs {
-    bucket  = module.alb_logs.aws_logs_bucket
-    prefix  = "api"
-    enabled = true
-  }
 }
 
 resource "aws_lb_target_group" "api" {
@@ -128,13 +122,6 @@ resource "aws_lb" "push" {
   enable_deletion_protection       = true
 
   tags = module.labels.tags
-
-  access_logs {
-    bucket  = module.alb_logs.aws_logs_bucket
-    prefix  = "push"
-    enabled = true
-  }
-
 }
 
 resource "aws_lb_target_group" "push" {
@@ -172,21 +159,4 @@ resource "aws_lb_listener" "push_https" {
     target_group_arn = aws_lb_target_group.push.id
     type             = "forward"
   }
-}
-
-# #########################################
-# ALB logs - single bucket for both ALBs each with their own prefix
-# #########################################
-module "alb_logs" {
-  source  = "trussworks/logs/aws"
-  version = "8.1.0"
-
-  alb_logs_prefixes       = ["api", "push"]
-  allow_alb               = true
-  default_allow           = false
-  force_destroy           = true
-  region                  = var.aws_region
-  s3_bucket_name          = format("%s-alb-logs", module.labels.id)
-  s3_log_bucket_retention = var.logs_retention_days
-  tags                    = module.labels.tags
 }

--- a/alb.tf
+++ b/alb.tf
@@ -31,6 +31,12 @@ resource "aws_lb" "api" {
   enable_deletion_protection       = true
 
   tags = module.labels.tags
+
+  access_logs {
+    bucket  = module.alb_logs.aws_logs_bucket
+    prefix  = "api"
+    enabled = true
+  }
 }
 
 resource "aws_lb_target_group" "api" {
@@ -122,6 +128,13 @@ resource "aws_lb" "push" {
   enable_deletion_protection       = true
 
   tags = module.labels.tags
+
+  access_logs {
+    bucket  = module.alb_logs.aws_logs_bucket
+    prefix  = "push"
+    enabled = true
+  }
+
 }
 
 resource "aws_lb_target_group" "push" {
@@ -159,4 +172,21 @@ resource "aws_lb_listener" "push_https" {
     target_group_arn = aws_lb_target_group.push.id
     type             = "forward"
   }
+}
+
+# #########################################
+# ALB logs - single bucket for both ALBs each with their own prefix
+# #########################################
+module "alb_logs" {
+  source  = "trussworks/logs/aws"
+  version = "8.1.0"
+
+  alb_logs_prefixes       = ["api", "push"]
+  allow_alb               = true
+  default_allow           = false
+  force_destroy           = true
+  region                  = var.aws_region
+  s3_bucket_name          = format("%s-alb-logs", module.labels.id)
+  s3_log_bucket_retention = var.logs_retention_days
+  tags                    = var.tags
 }

--- a/alb.tf
+++ b/alb.tf
@@ -188,5 +188,5 @@ module "alb_logs" {
   region                  = var.aws_region
   s3_bucket_name          = format("%s-alb-logs", module.labels.id)
   s3_log_bucket_retention = var.logs_retention_days
-  tags                    = var.tags
+  tags                    = module.labels.tags
 }

--- a/dashboard.tf
+++ b/dashboard.tf
@@ -1,25 +1,21 @@
-data "template_file" "dashboard" {
-  template = file(format("%s/templates/dashboard.json", path.module))
-
-  vars = {
-    account_id            = data.aws_caller_identity.current.account_id
-    region                = var.aws_region
-    environment           = var.environment
-    gateway_name          = "${module.labels.id}-gw"
-    ecs_cluster_name      = module.labels.id
-    ecs_push_service_name = aws_ecs_service.push.name
-    ecs_api_service_name  = aws_ecs_service.api.name
-    rds_db_cluster_name   = module.rds_cluster_aurora_postgres.cluster_identifier
-    lambda_token_fn_name  = "${module.labels.id}-token"
-    lambda_cso_fn_name    = "${module.labels.id}-cso"
-    lambda_stats_fn_name  = "${module.labels.id}-stats"
-    api_lb_arn_suffix     = aws_lb.api.arn_suffix
-    push_lb_arn_suffix    = aws_lb.push.arn_suffix
-    api_log_group         = "${module.labels.id}-api"
-  }
-}
-
 resource "aws_cloudwatch_dashboard" "monitoring_alarms_dashboard" {
   dashboard_name = module.labels.id
-  dashboard_body = data.template_file.dashboard.rendered
+
+  dashboard_body = templatefile(format("%s/templates/dashboard.json", path.module),
+    {
+      account_id            = data.aws_caller_identity.current.account_id
+      region                = var.aws_region
+      environment           = var.environment
+      gateway_name          = "${module.labels.id}-gw"
+      ecs_cluster_name      = module.labels.id
+      ecs_push_service_name = aws_ecs_service.push.name
+      ecs_api_service_name  = aws_ecs_service.api.name
+      rds_db_cluster_name   = module.rds_cluster_aurora_postgres.cluster_identifier
+      lambda_token_fn_name  = "${module.labels.id}-token"
+      lambda_cso_fn_name    = "${module.labels.id}-cso"
+      lambda_stats_fn_name  = "${module.labels.id}-stats"
+      api_lb_arn_suffix     = aws_lb.api.arn_suffix
+      push_lb_arn_suffix    = aws_lb.push.arn_suffix
+      api_log_group         = "${module.labels.id}-api"
+  })
 }

--- a/ecs_api.tf
+++ b/ecs_api.tf
@@ -92,21 +92,6 @@ resource "aws_iam_role_policy_attachment" "api_ecs_task_policy" {
 # #########################################
 # API Service
 # #########################################
-data "template_file" "api_service_container_definitions" {
-  template = file(format("%s/templates/api_service_task_definition.tpl", path.module))
-
-  vars = {
-    api_image_uri        = local.ecs_api_image_uri
-    config_var_prefix    = local.config_var_prefix
-    migrations_image_uri = local.ecs_migrations_image_uri
-    listening_port       = var.api_listening_port
-    logs_service_name    = aws_cloudwatch_log_group.api.name
-    log_group_region     = var.aws_region
-    node_env             = "production"
-    aws_region           = var.aws_region
-  }
-}
-
 resource "aws_ecs_task_definition" "api" {
   family                   = "${module.labels.id}-api"
   requires_compatibilities = ["FARGATE"]
@@ -115,9 +100,19 @@ resource "aws_ecs_task_definition" "api" {
   memory                   = var.api_services_task_memory
   execution_role_arn       = aws_iam_role.api_ecs_task_execution.arn
   task_role_arn            = aws_iam_role.api_ecs_task_role.arn
-  container_definitions    = data.template_file.api_service_container_definitions.rendered
+  tags                     = module.labels.tags
 
-  tags = module.labels.tags
+  container_definitions = templatefile(format("%s/templates/api_service_task_definition.tpl", path.module),
+    {
+      api_image_uri        = local.ecs_api_image_uri
+      config_var_prefix    = local.config_var_prefix
+      migrations_image_uri = local.ecs_migrations_image_uri
+      listening_port       = var.api_listening_port
+      logs_service_name    = aws_cloudwatch_log_group.api.name
+      log_group_region     = var.aws_region
+      node_env             = "production"
+      aws_region           = var.aws_region
+  })
 }
 
 resource "aws_ecs_service" "api" {

--- a/ecs_api.tf
+++ b/ecs_api.tf
@@ -105,13 +105,13 @@ resource "aws_ecs_task_definition" "api" {
   container_definitions = templatefile(format("%s/templates/api_service_task_definition.tpl", path.module),
     {
       api_image_uri        = local.ecs_api_image_uri
+      aws_region           = var.aws_region
       config_var_prefix    = local.config_var_prefix
       migrations_image_uri = local.ecs_migrations_image_uri
       listening_port       = var.api_listening_port
       logs_service_name    = aws_cloudwatch_log_group.api.name
       log_group_region     = var.aws_region
       node_env             = "production"
-      aws_region           = var.aws_region
   })
 }
 

--- a/ecs_push.tf
+++ b/ecs_push.tf
@@ -90,13 +90,13 @@ resource "aws_ecs_task_definition" "push" {
 
   container_definitions = templatefile(format("%s/templates/push_service_task_definition.tpl", path.module),
     {
+      aws_region        = var.aws_region
       config_var_prefix = local.config_var_prefix
       image_uri         = local.ecs_push_image_uri
       listening_port    = var.push_listening_port
       logs_service_name = aws_cloudwatch_log_group.push.name
       log_group_region  = var.aws_region
       node_env          = "production"
-      aws_region        = var.aws_region
   })
 }
 

--- a/ecs_push.tf
+++ b/ecs_push.tf
@@ -78,20 +78,6 @@ resource "aws_iam_role_policy_attachment" "push_ecs_task_policy" {
 # #########################################
 # Push Service
 # #########################################
-data "template_file" "push_service_container_definitions" {
-  template = file(format("%s/templates/push_service_task_definition.tpl", path.module))
-
-  vars = {
-    config_var_prefix = local.config_var_prefix
-    image_uri         = local.ecs_push_image_uri
-    listening_port    = var.push_listening_port
-    logs_service_name = aws_cloudwatch_log_group.push.name
-    log_group_region  = var.aws_region
-    node_env          = "production"
-    aws_region        = var.aws_region
-  }
-}
-
 resource "aws_ecs_task_definition" "push" {
   family                   = "${module.labels.id}-push"
   requires_compatibilities = ["FARGATE"]
@@ -100,9 +86,18 @@ resource "aws_ecs_task_definition" "push" {
   memory                   = var.push_services_task_memory
   execution_role_arn       = aws_iam_role.push_ecs_task_execution.arn
   task_role_arn            = aws_iam_role.push_ecs_task_role.arn
-  container_definitions    = data.template_file.push_service_container_definitions.rendered
+  tags                     = module.labels.tags
 
-  tags = module.labels.tags
+  container_definitions = templatefile(format("%s/templates/push_service_task_definition.tpl", path.module),
+    {
+      config_var_prefix = local.config_var_prefix
+      image_uri         = local.ecs_push_image_uri
+      listening_port    = var.push_listening_port
+      logs_service_name = aws_cloudwatch_log_group.push.name
+      log_group_region  = var.aws_region
+      node_env          = "production"
+      aws_region        = var.aws_region
+  })
 }
 
 resource "aws_ecs_service" "push" {

--- a/main.tf
+++ b/main.tf
@@ -7,6 +7,14 @@ terraform {
   # Leaving this, even though we have moved towards using this repo as a module - will ignore in that case
   # Also need to cater for git submodule/subtree usage for existing infrastructure
   backend "s3" {}
+
+  # Providers
+  required_providers {
+    archive = "~> 1.3.0"
+    aws     = "~> 2.70"
+    null    = "~> 2.1"
+    random  = "~> 2.0"
+  }
 }
 
 # #########################################
@@ -14,7 +22,6 @@ terraform {
 # #########################################
 # Main provider
 provider "aws" {
-  version = "2.68.0"
   region  = var.aws_region
   profile = var.profile
 }
@@ -22,7 +29,6 @@ provider "aws" {
 # Provider based on main but using us_east_1 as region
 # Will use this if creating a TLS certificate in us-east-1 region as required by CloudFront Edge used by the APIGateway
 provider "aws" {
-  version = "2.68.0"
   alias   = "us_east_1"
   region  = "us-east-1"
   profile = var.profile
@@ -31,27 +37,11 @@ provider "aws" {
 # DNS provider
 # Will use this if managing DNS, in some cases the Route53 zones are managed on a different account
 provider "aws" {
-  version = "2.68.0"
   alias   = "dns"
   region  = var.aws_region
   profile = var.dns_profile
 }
 
-
-# #########################################
-# Other providers
-# #########################################
-provider "null" {
-  version = "~> 2.1"
-}
-
-provider "random" {
-  version = "~> 2.0"
-}
-
-provider "archive" {
-  version = "~> 1.3.0"
-}
 
 # #########################################
 # Data

--- a/main.tf
+++ b/main.tf
@@ -45,10 +45,6 @@ provider "null" {
   version = "~> 2.1"
 }
 
-provider "template" {
-  version = "~> 2.1"
-}
-
 provider "random" {
   version = "~> 2.0"
 }

--- a/main.tf
+++ b/main.tf
@@ -46,8 +46,8 @@ provider "aws" {
 # #########################################
 # Data
 # #########################################
-data "aws_caller_identity" "current" {}
-
 data "aws_availability_zones" "available" {
   state = "available"
 }
+
+data "aws_caller_identity" "current" {}

--- a/remove-me-later.tf
+++ b/remove-me-later.tf
@@ -13,3 +13,8 @@ provider "aws" {
   region  = var.aws_region
   profile = var.dns_profile
 }
+
+## We keep this till we have applied all the way to prod and state files are updated
+provider "template" {
+  version = "~> 2.1"
+}

--- a/remove-me-later.tf
+++ b/remove-me-later.tf
@@ -1,14 +1,12 @@
 ## REMOVE THESE AFTER APPLIES ON ALL ENVS
 ## We keep this to allow the transition to be made in the state file, if we renamed the plan would balk indicating a missing provider
 provider "aws" {
-  version = "2.68.0"
   alias   = "us"
   region  = "us-east-1"
   profile = var.profile
 }
 
 provider "aws" {
-  version = "2.68.0"
   alias   = "root"
   region  = var.aws_region
   profile = var.dns_profile


### PR DESCRIPTION
See https://github.com/nearform/covid-tracker-infrastructure/issues/239

This prepares the content for adding ALB logging
- Updates the AWS provider from "**= 2.68.0**" to "**~> 2.70.0**" this is a requirement for the module we will use
- Replace deprecated template provider usage with templatefile function usage
   - Cannot remove this till we have applied on all envs as we need to update the TF state

Have checked these changes against a dev env and there are no changes on a plan