### PR TITLE
Add ALB logging - using a module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
-<a name="unreleased"></a>
 ## [Unreleased]
+- Added: ALB logging - both ALBs log to the same bucket, using distinct prefixes - api and push
 - Updated: Upgraded AWS provider from = 2.68.0 to ~> 2.70.0
 - Updated: Switched to using templatefile function rather than deprecated template provider
 
 
-<a name="v0.1.1"></a>
 ## [v0.1.1] 2020-08-13
 - Added: Added ability to set ECS image url and image tag overrides, this is based on @segfault's PR at https://github.com/covidgreen/covid-green-infra/pull/4
 - Updated: Switched lambdas from using the AWSLambdaBasicExecutionRole to AWSLambdaVPCAccessExecutionRole managed policy
@@ -30,6 +29,6 @@ All notable changes to this project will be documented in this file.
 - Fixed: Linting issues - no logic
 - Added: Split RDS user usage so we no longer need to use the master credentials
 
-<a name="v0.1.0"></a>
+
 ## [v0.1.0] 2020-08-13
 - Initial content

--- a/alb.tf
+++ b/alb.tf
@@ -29,8 +29,13 @@ resource "aws_lb" "api" {
   enable_http2                     = true
   ip_address_type                  = "dualstack"
   enable_deletion_protection       = true
+  tags                             = module.labels.tags
 
-  tags = module.labels.tags
+  access_logs {
+    bucket  = module.alb_logs.aws_logs_bucket
+    prefix  = "api"
+    enabled = true
+  }
 }
 
 resource "aws_lb_target_group" "api" {
@@ -120,8 +125,13 @@ resource "aws_lb" "push" {
   enable_http2                     = true
   ip_address_type                  = "dualstack"
   enable_deletion_protection       = true
+  tags                             = module.labels.tags
 
-  tags = module.labels.tags
+  access_logs {
+    bucket  = module.alb_logs.aws_logs_bucket
+    prefix  = "push"
+    enabled = true
+  }
 }
 
 resource "aws_lb_target_group" "push" {
@@ -159,4 +169,21 @@ resource "aws_lb_listener" "push_https" {
     target_group_arn = aws_lb_target_group.push.id
     type             = "forward"
   }
+}
+
+# #########################################
+# ALB logs - single bucket for both ALBs each with their own prefix
+# #########################################
+module "alb_logs" {
+  source  = "trussworks/logs/aws"
+  version = "8.1.0"
+
+  alb_logs_prefixes       = ["api", "push"]
+  allow_alb               = true
+  default_allow           = false
+  force_destroy           = true
+  region                  = var.aws_region
+  s3_bucket_name          = format("%s-alb-logs", module.labels.id)
+  s3_log_bucket_retention = var.logs_retention_days
+  tags                    = module.labels.tags
 }


### PR DESCRIPTION
See https://github.com/nearform/covid-tracker-infrastructure/issues/239

Uses the https://github.com/trussworks/terraform-aws-logs TF module where
- We use a single S3 bucket
- Use a prefix to distinguish between the api and the push ALB
