### PR TITLE
Restrict to specific RDS users rather than allowing access to admin user credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 
 ## [Unreleased]
+- Fixed: Fixed the "bastion_amazon_ssm_managed_instance_core" aws_iam_role_policy_attachment (Incorrect casing in name), this will result in a Terraform apply failure when applied, can run a second time to fix
 - Fixed: Removed RDS admin user access where not needed
 - Added: Added "verify" secret and changed "jwt_issuer" and "certificate_audience" parameters to support third party key server
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+
 ## [Unreleased]
+- Fixed: Removed RDS admin user access where not needed
 - Added: Added "verify" secret and changed "jwt_issuer" and "certificate_audience" parameters to support third party key server
 
 

--- a/bastion.tf
+++ b/bastion.tf
@@ -110,7 +110,7 @@ resource "aws_iam_role" "bastion" {
   })
 }
 
-resource "aws_iam_role_policy_attachment" "bastion_amazon_ssm_managed_Instance_core" {
+resource "aws_iam_role_policy_attachment" "bastion_amazon_ssm_managed_instance_core" {
   count      = local.bastion_enabled_count
   policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
   role       = aws_iam_role.bastion[0].name

--- a/docs/secrets-parameters.md
+++ b/docs/secrets-parameters.md
@@ -38,6 +38,9 @@ Parameters are managed by the Terraform content.
 	- daily_registrations_reporter_email_subject
 	- daily_registrations_reporter_sns_arn
 
+### Granting access to secrets and parameters
+When adding a new secret or parameter you will need to explicily add to the workload policies
+
 
 ### Generation of Secret Values
 

--- a/ecs_api.tf
+++ b/ecs_api.tf
@@ -29,7 +29,7 @@ resource "aws_iam_role" "api_ecs_task_role" {
 
 data "aws_iam_policy_document" "api_ecs_task_policy" {
   statement {
-    actions = ["ssm:GetParameter", "secretsmanager:GetSecretValue"]
+    actions = ["ssm:GetParameter"]
     resources = [
       aws_ssm_parameter.api_host.arn,
       aws_ssm_parameter.api_port.arn,
@@ -54,11 +54,16 @@ data "aws_iam_policy_document" "api_ecs_task_policy" {
       aws_ssm_parameter.security_refresh_token_expiry.arn,
       aws_ssm_parameter.security_token_lifetime_mins.arn,
       aws_ssm_parameter.security_verify_rate_limit_secs.arn,
-      aws_ssm_parameter.upload_token_lifetime_mins.arn,
+      aws_ssm_parameter.upload_token_lifetime_mins.arn
+    ]
+  }
+
+  statement {
+    actions = ["secretsmanager:GetSecretValue"]
+    resources = [
       data.aws_secretsmanager_secret_version.device_check.arn,
       data.aws_secretsmanager_secret_version.encrypt.arn,
       data.aws_secretsmanager_secret_version.jwt.arn,
-      data.aws_secretsmanager_secret_version.rds.arn,
       data.aws_secretsmanager_secret_version.rds_read_write_create.arn,
       data.aws_secretsmanager_secret_version.verify.arn
     ]

--- a/ecs_push.tf
+++ b/ecs_push.tf
@@ -14,7 +14,7 @@ data "aws_iam_policy_document" "push_ecs_assume_role_policy" {
 
 data "aws_iam_policy_document" "push_ecs_task_policy" {
   statement {
-    actions = ["ssm:GetParameter", "secretsmanager:GetSecretValue"]
+    actions = ["ssm:GetParameter"]
     resources = [
       aws_ssm_parameter.cors_origin.arn,
       aws_ssm_parameter.db_database.arn,
@@ -29,9 +29,14 @@ data "aws_iam_policy_document" "push_ecs_task_policy" {
       aws_ssm_parameter.security_code_charset.arn,
       aws_ssm_parameter.security_code_length.arn,
       aws_ssm_parameter.security_code_lifetime_mins.arn,
-      aws_ssm_parameter.sms_url.arn,
+      aws_ssm_parameter.sms_url.arn
+    ]
+  }
+
+  statement {
+    actions = ["secretsmanager:GetSecretValue"]
+    resources = [
       data.aws_secretsmanager_secret_version.jwt.arn,
-      data.aws_secretsmanager_secret_version.rds.arn,
       data.aws_secretsmanager_secret_version.rds_read_write.arn
     ]
   }

--- a/lambda-callback.tf
+++ b/lambda-callback.tf
@@ -8,11 +8,28 @@ data "aws_iam_policy_document" "callback_policy" {
   statement {
     actions = [
       "s3:*",
-      "secretsmanager:GetSecretValue",
-      "ssm:GetParameter",
       "sqs:*"
     ]
     resources = ["*"]
+  }
+
+  statement {
+    actions = ["secretsmanager:GetSecretValue"]
+    resources = [
+      data.aws_secretsmanager_secret_version.cct.arn,
+      data.aws_secretsmanager_secret_version.rds_read_write.arn
+    ]
+  }
+
+  statement {
+    actions = ["ssm:GetParameter"]
+    resources = [
+      aws_ssm_parameter.callback_url.arn,
+      aws_ssm_parameter.db_database.arn,
+      aws_ssm_parameter.db_host.arn,
+      aws_ssm_parameter.db_port.arn,
+      aws_ssm_parameter.db_ssl.arn
+    ]
   }
 
   statement {
@@ -31,7 +48,7 @@ data "aws_iam_policy_document" "callback_assume_role" {
       type = "Service"
 
       identifiers = [
-        "lambda.amazonaws.com",
+        "lambda.amazonaws.com"
       ]
     }
   }

--- a/lambda-callback.tf
+++ b/lambda-callback.tf
@@ -14,14 +14,6 @@ data "aws_iam_policy_document" "callback_policy" {
   }
 
   statement {
-    actions = ["secretsmanager:GetSecretValue"]
-    resources = [
-      data.aws_secretsmanager_secret_version.cct.arn,
-      data.aws_secretsmanager_secret_version.rds_read_write.arn
-    ]
-  }
-
-  statement {
     actions = ["ssm:GetParameter"]
     resources = [
       aws_ssm_parameter.callback_url.arn,
@@ -29,6 +21,14 @@ data "aws_iam_policy_document" "callback_policy" {
       aws_ssm_parameter.db_host.arn,
       aws_ssm_parameter.db_port.arn,
       aws_ssm_parameter.db_ssl.arn
+    ]
+  }
+
+  statement {
+    actions = ["secretsmanager:GetSecretValue"]
+    resources = [
+      data.aws_secretsmanager_secret_version.cct.arn,
+      data.aws_secretsmanager_secret_version.rds_read_write.arn
     ]
   }
 

--- a/lambda-callback.tf
+++ b/lambda-callback.tf
@@ -26,10 +26,10 @@ data "aws_iam_policy_document" "callback_policy" {
 
   statement {
     actions = ["secretsmanager:GetSecretValue"]
-    resources = [
-      data.aws_secretsmanager_secret_version.cct.arn,
-      data.aws_secretsmanager_secret_version.rds_read_write.arn
-    ]
+    resources = concat(
+      [data.aws_secretsmanager_secret_version.rds_read_write.arn],
+      data.aws_secretsmanager_secret_version.cct.*.arn
+    )
   }
 
   statement {

--- a/lambda-cso.tf
+++ b/lambda-cso.tf
@@ -22,10 +22,10 @@ data "aws_iam_policy_document" "cso_policy" {
 
   statement {
     actions = ["secretsmanager:GetSecretValue"]
-    resources = [
-      data.aws_secretsmanager_secret_version.cso.arn,
-      data.aws_secretsmanager_secret_version.rds_read_write.arn
-    ]
+    resources = concat(
+      [data.aws_secretsmanager_secret_version.rds_read_write.arn],
+      data.aws_secretsmanager_secret_version.cso.*.arn
+    )
   }
 }
 

--- a/lambda-cso.tf
+++ b/lambda-cso.tf
@@ -11,20 +11,20 @@ data "aws_iam_policy_document" "cso_policy" {
   }
 
   statement {
-    actions = ["secretsmanager:GetSecretValue"]
-    resources = [
-      data.aws_secretsmanager_secret_version.cso.arn,
-      data.aws_secretsmanager_secret_version.rds_read_write.arn
-    ]
-  }
-
-  statement {
     actions = ["ssm:GetParameter"]
     resources = [
       aws_ssm_parameter.db_database.arn,
       aws_ssm_parameter.db_host.arn,
       aws_ssm_parameter.db_port.arn,
       aws_ssm_parameter.db_ssl.arn
+    ]
+  }
+
+  statement {
+    actions = ["secretsmanager:GetSecretValue"]
+    resources = [
+      data.aws_secretsmanager_secret_version.cso.arn,
+      data.aws_secretsmanager_secret_version.rds_read_write.arn
     ]
   }
 }

--- a/lambda-cso.tf
+++ b/lambda-cso.tf
@@ -6,12 +6,26 @@ data "archive_file" "cso" {
 
 data "aws_iam_policy_document" "cso_policy" {
   statement {
-    actions = [
-      "s3:*",
-      "secretsmanager:GetSecretValue",
-      "ssm:GetParameter"
-    ]
+    actions   = ["s3:*"]
     resources = ["*"]
+  }
+
+  statement {
+    actions = ["secretsmanager:GetSecretValue"]
+    resources = [
+      data.aws_secretsmanager_secret_version.cso.arn,
+      data.aws_secretsmanager_secret_version.rds_read_write.arn
+    ]
+  }
+
+  statement {
+    actions = ["ssm:GetParameter"]
+    resources = [
+      aws_ssm_parameter.db_database.arn,
+      aws_ssm_parameter.db_host.arn,
+      aws_ssm_parameter.db_port.arn,
+      aws_ssm_parameter.db_ssl.arn
+    ]
   }
 }
 
@@ -23,7 +37,7 @@ data "aws_iam_policy_document" "cso_assume_role" {
       type = "Service"
 
       identifiers = [
-        "lambda.amazonaws.com",
+        "lambda.amazonaws.com"
       ]
     }
   }

--- a/lambda-daily-registrations-reporter.tf
+++ b/lambda-daily-registrations-reporter.tf
@@ -22,7 +22,7 @@ module "daily_registrations_reporter" {
     aws_ssm_parameter.daily_registrations_reporter_email_subject.*.arn,
     aws_ssm_parameter.daily_registrations_reporter_sns_arn.*.arn
   )
-  aws_secret_arns                = [data.aws_secretsmanager_secret_version.rds.arn, data.aws_secretsmanager_secret_version.rds_read_write.arn]
+  aws_secret_arns                = [data.aws_secretsmanager_secret_version.rds_read_write.arn]
   cloudwatch_schedule_expression = var.daily_registrations_reporter_schedule
   config_var_prefix              = local.config_var_prefix
   handler                        = "reporter.handler"

--- a/lambda-download.tf
+++ b/lambda-download.tf
@@ -17,7 +17,7 @@ module "download" {
     aws_ssm_parameter.db_reader_host.arn,
     aws_ssm_parameter.db_ssl.arn
   ]
-  aws_secret_arns                = concat([data.aws_secretsmanager_secret_version.rds.arn, data.aws_secretsmanager_secret_version.rds_read_write.arn], data.aws_secretsmanager_secret_version.interop.*.arn)
+  aws_secret_arns                = concat([data.aws_secretsmanager_secret_version.rds_read_write.arn], data.aws_secretsmanager_secret_version.interop.*.arn)
   cloudwatch_schedule_expression = var.download_schedule
   config_var_prefix              = local.config_var_prefix
   handler                        = "download.handler"

--- a/lambda-exposures.tf
+++ b/lambda-exposures.tf
@@ -7,11 +7,31 @@ data "archive_file" "exposures" {
 data "aws_iam_policy_document" "exposures_policy" {
   statement {
     actions = [
-      "s3:*",
-      "secretsmanager:GetSecretValue",
-      "ssm:GetParameter"
+      "s3:*"
     ]
     resources = ["*"]
+  }
+
+  statement {
+    actions = ["secretsmanager:GetSecretValue"]
+    resources = [
+      data.aws_secretsmanager_secret_version.exposures.arn,
+      data.aws_secretsmanager_secret_version.rds_read_write.arn
+    ]
+  }
+
+  statement {
+    actions = ["ssm:GetParameter"]
+    resources = [
+      aws_ssm_parameter.app_bundle_id.arn,
+      aws_ssm_parameter.db_database.arn,
+      aws_ssm_parameter.db_host.arn,
+      aws_ssm_parameter.db_port.arn,
+      aws_ssm_parameter.db_ssl.arn,
+      aws_ssm_parameter.default_region.arn,
+      aws_ssm_parameter.native_regions.arn,
+      aws_ssm_parameter.s3_assets_bucket.arn
+    ]
   }
 }
 
@@ -23,7 +43,7 @@ data "aws_iam_policy_document" "exposures_assume_role" {
       type = "Service"
 
       identifiers = [
-        "lambda.amazonaws.com",
+        "lambda.amazonaws.com"
       ]
     }
   }

--- a/lambda-exposures.tf
+++ b/lambda-exposures.tf
@@ -13,14 +13,6 @@ data "aws_iam_policy_document" "exposures_policy" {
   }
 
   statement {
-    actions = ["secretsmanager:GetSecretValue"]
-    resources = [
-      data.aws_secretsmanager_secret_version.exposures.arn,
-      data.aws_secretsmanager_secret_version.rds_read_write.arn
-    ]
-  }
-
-  statement {
     actions = ["ssm:GetParameter"]
     resources = [
       aws_ssm_parameter.app_bundle_id.arn,
@@ -31,6 +23,14 @@ data "aws_iam_policy_document" "exposures_policy" {
       aws_ssm_parameter.default_region.arn,
       aws_ssm_parameter.native_regions.arn,
       aws_ssm_parameter.s3_assets_bucket.arn
+    ]
+  }
+
+  statement {
+    actions = ["secretsmanager:GetSecretValue"]
+    resources = [
+      data.aws_secretsmanager_secret_version.exposures.arn,
+      data.aws_secretsmanager_secret_version.rds_read_write.arn
     ]
   }
 }

--- a/lambda-settings.tf
+++ b/lambda-settings.tf
@@ -13,13 +13,6 @@ data "aws_iam_policy_document" "settings_policy" {
   }
 
   statement {
-    actions = ["secretsmanager:GetSecretValue"]
-    resources = [
-      data.aws_secretsmanager_secret_version.rds_read_write.arn
-    ]
-  }
-
-  statement {
     actions = ["ssm:GetParameter"]
     resources = [
       aws_ssm_parameter.db_database.arn,
@@ -27,6 +20,13 @@ data "aws_iam_policy_document" "settings_policy" {
       aws_ssm_parameter.db_port.arn,
       aws_ssm_parameter.db_ssl.arn,
       aws_ssm_parameter.s3_assets_bucket.arn
+    ]
+  }
+
+  statement {
+    actions = ["secretsmanager:GetSecretValue"]
+    resources = [
+      data.aws_secretsmanager_secret_version.rds_read_write.arn
     ]
   }
 }

--- a/lambda-settings.tf
+++ b/lambda-settings.tf
@@ -7,11 +7,27 @@ data "archive_file" "settings" {
 data "aws_iam_policy_document" "settings_policy" {
   statement {
     actions = [
-      "s3:*",
-      "secretsmanager:GetSecretValue",
-      "ssm:GetParameter"
+      "s3:*"
     ]
     resources = ["*"]
+  }
+
+  statement {
+    actions = ["secretsmanager:GetSecretValue"]
+    resources = [
+      data.aws_secretsmanager_secret_version.rds_read_write.arn
+    ]
+  }
+
+  statement {
+    actions = ["ssm:GetParameter"]
+    resources = [
+      aws_ssm_parameter.db_database.arn,
+      aws_ssm_parameter.db_host.arn,
+      aws_ssm_parameter.db_port.arn,
+      aws_ssm_parameter.db_ssl.arn,
+      aws_ssm_parameter.s3_assets_bucket.arn
+    ]
   }
 }
 
@@ -23,7 +39,7 @@ data "aws_iam_policy_document" "settings_assume_role" {
       type = "Service"
 
       identifiers = [
-        "lambda.amazonaws.com",
+        "lambda.amazonaws.com"
       ]
     }
   }

--- a/lambda-sms.tf
+++ b/lambda-sms.tf
@@ -23,7 +23,7 @@ module "sms" {
     aws_ssm_parameter.sms_template.arn,
     aws_ssm_parameter.sms_url.arn
   ]
-  aws_secret_arns                            = concat([data.aws_secretsmanager_secret_version.rds.arn, data.aws_secretsmanager_secret_version.rds_read_write.arn], data.aws_secretsmanager_secret_version.sms.*.arn)
+  aws_secret_arns                            = concat([data.aws_secretsmanager_secret_version.rds_read_write.arn], data.aws_secretsmanager_secret_version.sms.*.arn)
   config_var_prefix                          = local.config_var_prefix
   enable_sns_publish_for_sms_without_a_topic = var.enable_sms_publishing_with_aws
   handler                                    = "sms.handler"

--- a/lambda-stats.tf
+++ b/lambda-stats.tf
@@ -11,13 +11,6 @@ data "aws_iam_policy_document" "stats_policy" {
   }
 
   statement {
-    actions = ["secretsmanager:GetSecretValue"]
-    resources = [
-      data.aws_secretsmanager_secret_version.rds_read_write.arn
-    ]
-  }
-
-  statement {
     actions = ["ssm:GetParameter"]
     resources = [
       aws_ssm_parameter.arcgis_url.arn,
@@ -26,6 +19,13 @@ data "aws_iam_policy_document" "stats_policy" {
       aws_ssm_parameter.db_port.arn,
       aws_ssm_parameter.db_ssl.arn,
       aws_ssm_parameter.s3_assets_bucket.arn
+    ]
+  }
+
+  statement {
+    actions = ["secretsmanager:GetSecretValue"]
+    resources = [
+      data.aws_secretsmanager_secret_version.rds_read_write.arn
     ]
   }
 }

--- a/lambda-stats.tf
+++ b/lambda-stats.tf
@@ -6,12 +6,27 @@ data "archive_file" "stats" {
 
 data "aws_iam_policy_document" "stats_policy" {
   statement {
-    actions = [
-      "s3:*",
-      "secretsmanager:GetSecretValue",
-      "ssm:GetParameter"
-    ]
+    actions   = ["s3:*"]
     resources = ["*"]
+  }
+
+  statement {
+    actions = ["secretsmanager:GetSecretValue"]
+    resources = [
+      data.aws_secretsmanager_secret_version.rds_read_write.arn
+    ]
+  }
+
+  statement {
+    actions = ["ssm:GetParameter"]
+    resources = [
+      aws_ssm_parameter.arcgis_url.arn,
+      aws_ssm_parameter.db_database.arn,
+      aws_ssm_parameter.db_host.arn,
+      aws_ssm_parameter.db_port.arn,
+      aws_ssm_parameter.db_ssl.arn,
+      aws_ssm_parameter.s3_assets_bucket.arn
+    ]
   }
 }
 
@@ -23,7 +38,7 @@ data "aws_iam_policy_document" "stats_assume_role" {
       type = "Service"
 
       identifiers = [
-        "lambda.amazonaws.com",
+        "lambda.amazonaws.com"
       ]
     }
   }

--- a/lambda-stats.tf
+++ b/lambda-stats.tf
@@ -12,14 +12,16 @@ data "aws_iam_policy_document" "stats_policy" {
 
   statement {
     actions = ["ssm:GetParameter"]
-    resources = [
-      aws_ssm_parameter.arcgis_url.arn,
-      aws_ssm_parameter.db_database.arn,
-      aws_ssm_parameter.db_host.arn,
-      aws_ssm_parameter.db_port.arn,
-      aws_ssm_parameter.db_ssl.arn,
-      aws_ssm_parameter.s3_assets_bucket.arn
-    ]
+    resources = concat(
+      [
+        aws_ssm_parameter.db_database.arn,
+        aws_ssm_parameter.db_host.arn,
+        aws_ssm_parameter.db_port.arn,
+        aws_ssm_parameter.db_ssl.arn,
+        aws_ssm_parameter.s3_assets_bucket.arn
+      ],
+      aws_ssm_parameter.arcgis_url.*.arn
+    )
   }
 
   statement {

--- a/lambda-token.tf
+++ b/lambda-token.tf
@@ -11,20 +11,20 @@ data "aws_iam_policy_document" "token_policy" {
   }
 
   statement {
-    actions = ["secretsmanager:GetSecretValue"]
-    resources = [
-      data.aws_secretsmanager_secret_version.jwt.arn,
-      data.aws_secretsmanager_secret_version.rds_read_write.arn
-    ]
-  }
-
-  statement {
     actions = ["ssm:GetParameter"]
     resources = [
       aws_ssm_parameter.db_database.arn,
       aws_ssm_parameter.db_host.arn,
       aws_ssm_parameter.db_port.arn,
       aws_ssm_parameter.db_ssl.arn
+    ]
+  }
+
+  statement {
+    actions = ["secretsmanager:GetSecretValue"]
+    resources = [
+      data.aws_secretsmanager_secret_version.jwt.arn,
+      data.aws_secretsmanager_secret_version.rds_read_write.arn
     ]
   }
 }

--- a/lambda-token.tf
+++ b/lambda-token.tf
@@ -6,12 +6,26 @@ data "archive_file" "token" {
 
 data "aws_iam_policy_document" "token_policy" {
   statement {
-    actions = [
-      "s3:*",
-      "secretsmanager:GetSecretValue",
-      "ssm:GetParameter"
-    ]
+    actions   = ["s3:*"]
     resources = ["*"]
+  }
+
+  statement {
+    actions = ["secretsmanager:GetSecretValue"]
+    resources = [
+      data.aws_secretsmanager_secret_version.jwt.arn,
+      data.aws_secretsmanager_secret_version.rds_read_write.arn
+    ]
+  }
+
+  statement {
+    actions = ["ssm:GetParameter"]
+    resources = [
+      aws_ssm_parameter.db_database.arn,
+      aws_ssm_parameter.db_host.arn,
+      aws_ssm_parameter.db_port.arn,
+      aws_ssm_parameter.db_ssl.arn
+    ]
   }
 }
 
@@ -23,7 +37,7 @@ data "aws_iam_policy_document" "token_assume_role" {
       type = "Service"
 
       identifiers = [
-        "lambda.amazonaws.com",
+        "lambda.amazonaws.com"
       ]
     }
   }

--- a/lambda-upload.tf
+++ b/lambda-upload.tf
@@ -17,7 +17,7 @@ module "upload" {
     aws_ssm_parameter.db_reader_host.arn,
     aws_ssm_parameter.db_ssl.arn
   ]
-  aws_secret_arns                = concat([data.aws_secretsmanager_secret_version.rds.arn, data.aws_secretsmanager_secret_version.rds_read_write.arn], data.aws_secretsmanager_secret_version.interop.*.arn)
+  aws_secret_arns                = concat([data.aws_secretsmanager_secret_version.rds_read_write.arn], data.aws_secretsmanager_secret_version.interop.*.arn)
   cloudwatch_schedule_expression = var.upload_schedule
   config_var_prefix              = local.config_var_prefix
   handler                        = "upload.handler"

--- a/scripts/create-tf-state-backend.sh
+++ b/scripts/create-tf-state-backend.sh
@@ -40,7 +40,7 @@ aws s3api put-bucket-versioning --bucket ${s3_bucket_name} --versioning-configur
 # Apply block public access config
 aws s3api put-public-access-block \
 	--bucket ${s3_bucket_name} \
-	--public-access-block-configuration "BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true" \
+	--public-access-block-configuration "BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true"
 
 
 # DynamoDb table


### PR DESCRIPTION
Remove access to rds_admin credentials

Doing this in a number of passes
- Will apply first on dela-qa, jers-qa, penn-qa and scot-qa - these all use the TF module
- Will need to next visit the other workloads - done
- Will need to apply on cti-dev, gct-dev, ni-dev, cti-qa and ni-qa