### PR TITLE
Allow callback email notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 
 ## [Unreleased]
+- Added: Added option to send callback notifications using email via an SNS topic - subscription will not be automated
 - Fixed: Altered the ECS image so the custom vars are just for the image and do not include the tag, we append the tag if using a custom image using the tag var
 - Fixed: Fixed the "bastion_amazon_ssm_managed_instance_core" aws_iam_role_policy_attachment (Incorrect casing in name), this will result in a Terraform apply failure when applied, can run a second time to fix
 - Fixed: Removed RDS admin user access where not needed

--- a/lambda-callback.tf
+++ b/lambda-callback.tf
@@ -23,7 +23,7 @@ data "aws_iam_policy_document" "callback_policy" {
         aws_ssm_parameter.db_port.arn,
         aws_ssm_parameter.db_ssl.arn
       ],
-      aws_ssm_parameter.callback_email_notifications_sns_arn.arn
+      aws_ssm_parameter.callback_email_notifications_sns_arn.*.arn
     )
   }
 

--- a/lambda-callback.tf
+++ b/lambda-callback.tf
@@ -41,6 +41,14 @@ data "aws_iam_policy_document" "callback_policy" {
       aws_kms_key.sqs.arn
     ]
   }
+
+  dynamic statement {
+    for_each = local.enable_callback_email_notifications_count > 0 ? { 1 : 1 } : {}
+    content {
+      actions   = ["sns:Publish"]
+      resources = aws_sns_topic.callback_email_notifications.*.arn
+    }
+  }
 }
 
 data "aws_iam_policy_document" "callback_assume_role" {

--- a/lambda-callback.tf
+++ b/lambda-callback.tf
@@ -15,13 +15,16 @@ data "aws_iam_policy_document" "callback_policy" {
 
   statement {
     actions = ["ssm:GetParameter"]
-    resources = [
-      aws_ssm_parameter.callback_url.arn,
-      aws_ssm_parameter.db_database.arn,
-      aws_ssm_parameter.db_host.arn,
-      aws_ssm_parameter.db_port.arn,
-      aws_ssm_parameter.db_ssl.arn
-    ]
+    resources = concat(
+      [
+        aws_ssm_parameter.callback_url.arn,
+        aws_ssm_parameter.db_database.arn,
+        aws_ssm_parameter.db_host.arn,
+        aws_ssm_parameter.db_port.arn,
+        aws_ssm_parameter.db_ssl.arn
+      ],
+      aws_ssm_parameter.callback_email_notifications_sns_arn.arn
+    )
   }
 
   statement {

--- a/locals.tf
+++ b/locals.tf
@@ -20,7 +20,7 @@ locals {
   ecs_push_image       = format("%s:%s", coalesce(var.push_custom_image, aws_ecr_repository.push.repository_url), var.push_image_tag)
 
   # Based on flag
-  enable_callback_email_notifications_count = var.enable_callback_email_notifications ? 1 : 0
+  enable_callback_email_notifications_count = var.enable_callback && var.enable_callback_email_notifications ? 1 : 0
 
   # Based on flag
   enable_certificates_count = var.enable_certificates ? 1 : 0

--- a/locals.tf
+++ b/locals.tf
@@ -20,6 +20,9 @@ locals {
   ecs_push_image       = format("%s:%s", coalesce(var.push_custom_image, aws_ecr_repository.push.repository_url), var.push_image_tag)
 
   # Based on flag
+  enable_callback_email_notifications_count = var.enable_callback_email_notifications ? 1 : 0
+
+  # Based on flag
   enable_certificates_count = var.enable_certificates ? 1 : 0
 
   # Based on flag

--- a/parameters.tf
+++ b/parameters.tf
@@ -293,6 +293,15 @@ resource "aws_ssm_parameter" "arcgis_url" {
   tags      = module.labels.tags
 }
 
+resource "aws_ssm_parameter" "callback_email_notifications_sns_arn" {
+  count     = local.enable_callback_email_notifications_count
+  overwrite = true
+  name      = "${local.config_var_prefix}callback_email_notifications_sns_arn"
+  type      = "String"
+  value     = join("", aws_sns_topic.callback_email_notifications.*.arn)
+  tags      = module.labels.tags
+}
+
 resource "aws_ssm_parameter" "daily_registrations_reporter_email_subject" {
   count     = contains(var.optional_parameters_to_include, "daily_registrations_reporter_email_subject") ? 1 : 0
   overwrite = true

--- a/sns.tf
+++ b/sns.tf
@@ -9,7 +9,7 @@ resource "aws_sns_topic" "callback_email_notifications" {
   tags              = module.labels.tags
 }
 
-resource "aws_sns_topic" "email_registrations_reporter" {
+resource "aws_sns_topic" "daily_registrations_reporter" {
   count = local.lambda_daily_registrations_reporter_count
 
   name              = "${module.labels.id}-daily-registrations-reporter"

--- a/sns.tf
+++ b/sns.tf
@@ -1,7 +1,15 @@
 # #########################################
 # SNS
 # #########################################
-resource "aws_sns_topic" "daily_registrations_reporter" {
+resource "aws_sns_topic" "callback_email_notifications" {
+  count = local.enable_callback_email_notifications_count
+
+  name              = "${module.labels.id}-callback-email-notifications"
+  kms_master_key_id = aws_kms_alias.sns.arn
+  tags              = module.labels.tags
+}
+
+resource "aws_sns_topic" "email_registrations_reporter" {
   count = local.lambda_daily_registrations_reporter_count
 
   name              = "${module.labels.id}-daily-registrations-reporter"

--- a/variables.tf
+++ b/variables.tf
@@ -360,6 +360,9 @@ variable "lambda_exposures_memory_size" {
 variable "lambda_exposures_timeout" {
   default = 15
 }
+variable "lambda_provisioned_concurrencies" {
+  default = {}
+}
 variable "lambda_settings_memory_size" {
   default = 128
 }
@@ -368,9 +371,6 @@ variable "lambda_settings_timeout" {
 }
 variable "lambda_sms_memory_size" {
   default = 128
-}
-variable "lambda_provisioned_concurrencies" {
-  default = {}
 }
 variable "lambda_sms_timeout" {
   default = 15

--- a/variables.tf
+++ b/variables.tf
@@ -303,6 +303,9 @@ variable "app_bundle_id" {
 variable "enable_callback" {
   default = "true"
 }
+variable "enable_callback_email_notifications" {
+  default = "false"
+}
 variable "enable_check_in" {
   default = "true"
 }


### PR DESCRIPTION
See https://github.com/nearform/covid-tracker-infrastructure/issues/253

Add option to sending callback notifications using email
- Will conditionally create an SNS topic
- Will allow the callback lambda publish on a SNS topic
- Subscription to use an email subscriber will not be automated