### PR TITLE
Allow using S3 as lambda source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 
 ## [Unreleased]
+- Added: Option to use an S3 bucket as the source for lambdas, will be a global setting and we do not manage this bucket as this is a non default option
 - Added: Added option to send callback notifications using email via an SNS topic - subscription will not be automated
 - Fixed: Altered the ECS image so the custom vars are just for the image and do not include the tag, we append the tag if using a custom image using the tag var
 - Fixed: Fixed the "bastion_amazon_ssm_managed_instance_core" aws_iam_role_policy_attachment (Incorrect casing in name), this will result in a Terraform apply failure when applied, can run a second time to fix

--- a/lambda-authorizer.tf
+++ b/lambda-authorizer.tf
@@ -58,15 +58,19 @@ resource "aws_iam_role_policy_attachment" "authorizer_logs" {
 }
 
 resource "aws_lambda_function" "authorizer" {
-  filename         = "${path.module}/.zip/${module.labels.id}_authorizer.zip"
-  function_name    = "${module.labels.id}-authorizer"
-  source_code_hash = data.archive_file.authorizer.output_base64sha256
-  role             = aws_iam_role.authorizer.arn
-  runtime          = "nodejs12.x"
-  handler          = "authorizer.handler"
-  memory_size      = var.lambda_authorizer_memory_size
-  timeout          = var.lambda_authorizer_timeout
-  tags             = module.labels.tags
+  # Default is to use the stub file, but we need to cater for S3 bucket file being the source
+  filename         = local.lambdas_using_s3_as_source ? null : "${path.module}/.zip/${module.labels.id}_authorizer.zip"
+  s3_bucket        = local.lambdas_using_s3_as_source ? var.lambdas_custom_s3_bucket : null
+  s3_key           = local.lambdas_using_s3_as_source ? var.lambda_authorizer_s3_key : null
+  source_code_hash = local.lambdas_using_s3_as_source ? "" : data.archive_file.authorizer.output_base64sha256
+
+  function_name = "${module.labels.id}-authorizer"
+  handler       = "authorizer.handler"
+  memory_size   = var.lambda_authorizer_memory_size
+  role          = aws_iam_role.authorizer.arn
+  runtime       = "nodejs12.x"
+  tags          = module.labels.tags
+  timeout       = var.lambda_authorizer_timeout
 
   depends_on = [aws_cloudwatch_log_group.authorizer]
 

--- a/lambda-authorizer.tf
+++ b/lambda-authorizer.tf
@@ -59,10 +59,10 @@ resource "aws_iam_role_policy_attachment" "authorizer_logs" {
 
 resource "aws_lambda_function" "authorizer" {
   # Default is to use the stub file, but we need to cater for S3 bucket file being the source
-  filename         = local.lambdas_using_s3_as_source ? null : "${path.module}/.zip/${module.labels.id}_authorizer.zip"
-  s3_bucket        = local.lambdas_using_s3_as_source ? var.lambdas_custom_s3_bucket : null
-  s3_key           = local.lambdas_using_s3_as_source ? var.lambda_authorizer_s3_key : null
-  source_code_hash = local.lambdas_using_s3_as_source ? "" : data.archive_file.authorizer.output_base64sha256
+  filename         = local.lambdas_use_s3_as_source ? null : "${path.module}/.zip/${module.labels.id}_authorizer.zip"
+  s3_bucket        = local.lambdas_use_s3_as_source ? var.lambdas_custom_s3_bucket : null
+  s3_key           = local.lambdas_use_s3_as_source ? var.lambda_authorizer_s3_key : null
+  source_code_hash = local.lambdas_use_s3_as_source ? "" : data.archive_file.authorizer.output_base64sha256
 
   function_name = "${module.labels.id}-authorizer"
   handler       = "authorizer.handler"

--- a/lambda-callback.tf
+++ b/lambda-callback.tf
@@ -104,10 +104,10 @@ resource "aws_iam_role_policy_attachment" "callback_aws_managed_policy" {
 
 resource "aws_lambda_function" "callback" {
   # Default is to use the stub file, but we need to cater for S3 bucket file being the source
-  filename         = local.lambdas_using_s3_as_source ? null : "${path.module}/.zip/${module.labels.id}_callback.zip"
-  s3_bucket        = local.lambdas_using_s3_as_source ? var.lambdas_custom_s3_bucket : null
-  s3_key           = local.lambdas_using_s3_as_source ? var.lambda_callback_s3_key : null
-  source_code_hash = local.lambdas_using_s3_as_source ? "" : data.archive_file.callback.output_base64sha256
+  filename         = local.lambdas_use_s3_as_source ? null : "${path.module}/.zip/${module.labels.id}_callback.zip"
+  s3_bucket        = local.lambdas_use_s3_as_source ? var.lambdas_custom_s3_bucket : null
+  s3_key           = local.lambdas_use_s3_as_source ? var.lambda_callback_s3_key : null
+  source_code_hash = local.lambdas_use_s3_as_source ? "" : data.archive_file.callback.output_base64sha256
 
   function_name = "${module.labels.id}-callback"
   handler       = "callback.handler"

--- a/lambda-callback.tf
+++ b/lambda-callback.tf
@@ -103,22 +103,21 @@ resource "aws_iam_role_policy_attachment" "callback_aws_managed_policy" {
 }
 
 resource "aws_lambda_function" "callback" {
-  filename         = "${path.module}/.zip/${module.labels.id}_callback.zip"
-  function_name    = "${module.labels.id}-callback"
-  source_code_hash = data.archive_file.callback.output_base64sha256
-  role             = aws_iam_role.callback.arn
-  runtime          = "nodejs12.x"
-  handler          = "callback.handler"
-  memory_size      = var.lambda_callback_memory_size
-  timeout          = var.lambda_callback_timeout
-  tags             = module.labels.tags
+  # Default is to use the stub file, but we need to cater for S3 bucket file being the source
+  filename         = local.lambdas_using_s3_as_source ? null : "${path.module}/.zip/${module.labels.id}_callback.zip"
+  s3_bucket        = local.lambdas_using_s3_as_source ? var.lambdas_custom_s3_bucket : null
+  s3_key           = local.lambdas_using_s3_as_source ? var.lambda_callback_s3_key : null
+  source_code_hash = local.lambdas_using_s3_as_source ? "" : data.archive_file.callback.output_base64sha256
+
+  function_name = "${module.labels.id}-callback"
+  handler       = "callback.handler"
+  memory_size   = var.lambda_callback_memory_size
+  role          = aws_iam_role.callback.arn
+  runtime       = "nodejs12.x"
+  tags          = module.labels.tags
+  timeout       = var.lambda_callback_timeout
 
   depends_on = [aws_cloudwatch_log_group.callback]
-
-  vpc_config {
-    security_group_ids = [module.lambda_sg.id]
-    subnet_ids         = module.vpc.private_subnets
-  }
 
   environment {
     variables = {
@@ -131,6 +130,11 @@ resource "aws_lambda_function" "callback" {
     ignore_changes = [
       source_code_hash,
     ]
+  }
+
+  vpc_config {
+    security_group_ids = [module.lambda_sg.id]
+    subnet_ids         = module.vpc.private_subnets
   }
 }
 

--- a/lambda-cso.tf
+++ b/lambda-cso.tf
@@ -80,10 +80,10 @@ resource "aws_lambda_function" "cso" {
   count = local.lambda_cso_count
 
   # Default is to use the stub file, but we need to cater for S3 bucket file being the source
-  filename         = local.lambdas_using_s3_as_source ? null : "${path.module}/.zip/${module.labels.id}_cso.zip"
-  s3_bucket        = local.lambdas_using_s3_as_source ? var.lambdas_custom_s3_bucket : null
-  s3_key           = local.lambdas_using_s3_as_source ? var.lambda_cso_s3_key : null
-  source_code_hash = local.lambdas_using_s3_as_source ? "" : data.archive_file.cso.output_base64sha256
+  filename         = local.lambdas_use_s3_as_source ? null : "${path.module}/.zip/${module.labels.id}_cso.zip"
+  s3_bucket        = local.lambdas_use_s3_as_source ? var.lambdas_custom_s3_bucket : null
+  s3_key           = local.lambdas_use_s3_as_source ? var.lambda_cso_s3_key : null
+  source_code_hash = local.lambdas_use_s3_as_source ? "" : data.archive_file.cso.output_base64sha256
 
   function_name = "${module.labels.id}-cso"
   handler       = "cso.handler"

--- a/lambda-cso.tf
+++ b/lambda-cso.tf
@@ -83,7 +83,7 @@ resource "aws_lambda_function" "cso" {
   filename         = local.lambdas_using_s3_as_source ? null : "${path.module}/.zip/${module.labels.id}_cso.zip"
   s3_bucket        = local.lambdas_using_s3_as_source ? var.lambdas_custom_s3_bucket : null
   s3_key           = local.lambdas_using_s3_as_source ? var.lambda_cso_s3_key : null
-  source_code_hash = local.lambdas_using_s3_as_source ? "" : data.archive_file.cso[0].output_base64sha256
+  source_code_hash = local.lambdas_using_s3_as_source ? "" : data.archive_file.cso.output_base64sha256
 
   function_name = "${module.labels.id}-cso"
   handler       = "cso.handler"

--- a/lambda-cso.tf
+++ b/lambda-cso.tf
@@ -77,23 +77,23 @@ resource "aws_iam_role_policy_attachment" "cso_aws_managed_policy" {
 }
 
 resource "aws_lambda_function" "cso" {
-  count            = local.lambda_cso_count
-  filename         = "${path.module}/.zip/${module.labels.id}_cso.zip"
-  function_name    = "${module.labels.id}-cso"
-  source_code_hash = data.archive_file.cso.output_base64sha256
-  role             = aws_iam_role.cso[0].arn
-  runtime          = "nodejs12.x"
-  handler          = "cso.handler"
-  memory_size      = var.lambda_cso_memory_size
-  timeout          = var.lambda_cso_timeout
-  tags             = module.labels.tags
+  count = local.lambda_cso_count
+
+  # Default is to use the stub file, but we need to cater for S3 bucket file being the source
+  filename         = local.lambdas_using_s3_as_source ? null : "${path.module}/.zip/${module.labels.id}_cso.zip"
+  s3_bucket        = local.lambdas_using_s3_as_source ? var.lambdas_custom_s3_bucket : null
+  s3_key           = local.lambdas_using_s3_as_source ? var.lambda_cso_s3_key : null
+  source_code_hash = local.lambdas_using_s3_as_source ? "" : data.archive_file.cso[0].output_base64sha256
+
+  function_name = "${module.labels.id}-cso"
+  handler       = "cso.handler"
+  memory_size   = var.lambda_cso_memory_size
+  role          = aws_iam_role.cso[0].arn
+  runtime       = "nodejs12.x"
+  tags          = module.labels.tags
+  timeout       = var.lambda_cso_timeout
 
   depends_on = [aws_cloudwatch_log_group.cso]
-
-  vpc_config {
-    security_group_ids = [module.lambda_sg.id]
-    subnet_ids         = module.vpc.private_subnets
-  }
 
   environment {
     variables = {
@@ -106,6 +106,11 @@ resource "aws_lambda_function" "cso" {
     ignore_changes = [
       source_code_hash,
     ]
+  }
+
+  vpc_config {
+    security_group_ids = [module.lambda_sg.id]
+    subnet_ids         = module.vpc.private_subnets
   }
 }
 

--- a/lambda-daily-registrations-reporter.tf
+++ b/lambda-daily-registrations-reporter.tf
@@ -29,6 +29,8 @@ module "daily_registrations_reporter" {
   kms_writer_arns                = [aws_kms_key.sns.arn]
   log_retention_days             = var.logs_retention_days
   memory_size                    = var.lambda_daily_registrations_reporter_memory_size
+  s3_bucket                      = var.lambdas_custom_s3_bucket
+  s3_key                         = var.lambda_daily_registrations_reporter_s3_key
   security_group_ids             = [module.lambda_sg.id]
   sns_topic_arns_to_publish_to   = aws_sns_topic.daily_registrations_reporter.*.arn
   subnet_ids                     = module.vpc.private_subnets

--- a/lambda-download.tf
+++ b/lambda-download.tf
@@ -23,6 +23,8 @@ module "download" {
   handler                        = "download.handler"
   log_retention_days             = var.logs_retention_days
   memory_size                    = var.lambda_download_memory_size
+  s3_bucket                      = var.lambdas_custom_s3_bucket
+  s3_key                         = var.lambda_download_s3_key
   security_group_ids             = [module.lambda_sg.id]
   subnet_ids                     = module.vpc.private_subnets
   tags                           = module.labels.tags

--- a/lambda-exposures.tf
+++ b/lambda-exposures.tf
@@ -79,10 +79,10 @@ resource "aws_iam_role_policy_attachment" "exposures_aws_managed_policy" {
 
 resource "aws_lambda_function" "exposures" {
   # Default is to use the stub file, but we need to cater for S3 bucket file being the source
-  filename         = local.lambdas_using_s3_as_source ? null : "${path.module}/.zip/${module.labels.id}_exposures.zip"
-  s3_bucket        = local.lambdas_using_s3_as_source ? var.lambdas_custom_s3_bucket : null
-  s3_key           = local.lambdas_using_s3_as_source ? var.lambda_exposures_s3_key : null
-  source_code_hash = local.lambdas_using_s3_as_source ? "" : data.archive_file.exposures.output_base64sha256
+  filename         = local.lambdas_use_s3_as_source ? null : "${path.module}/.zip/${module.labels.id}_exposures.zip"
+  s3_bucket        = local.lambdas_use_s3_as_source ? var.lambdas_custom_s3_bucket : null
+  s3_key           = local.lambdas_use_s3_as_source ? var.lambda_exposures_s3_key : null
+  source_code_hash = local.lambdas_use_s3_as_source ? "" : data.archive_file.exposures.output_base64sha256
 
   function_name = "${module.labels.id}-exposures"
   handler       = "exposures.handler"

--- a/lambda-exposures.tf
+++ b/lambda-exposures.tf
@@ -78,22 +78,21 @@ resource "aws_iam_role_policy_attachment" "exposures_aws_managed_policy" {
 }
 
 resource "aws_lambda_function" "exposures" {
-  filename         = "${path.module}/.zip/${module.labels.id}_exposures.zip"
-  function_name    = "${module.labels.id}-exposures"
-  source_code_hash = data.archive_file.exposures.output_base64sha256
-  role             = aws_iam_role.exposures.arn
-  runtime          = "nodejs12.x"
-  handler          = "exposures.handler"
-  memory_size      = var.lambda_exposures_memory_size
-  timeout          = var.lambda_exposures_timeout
-  tags             = module.labels.tags
+  # Default is to use the stub file, but we need to cater for S3 bucket file being the source
+  filename         = local.lambdas_using_s3_as_source ? null : "${path.module}/.zip/${module.labels.id}_exposures.zip"
+  s3_bucket        = local.lambdas_using_s3_as_source ? var.lambdas_custom_s3_bucket : null
+  s3_key           = local.lambdas_using_s3_as_source ? var.lambda_exposures_s3_key : null
+  source_code_hash = local.lambdas_using_s3_as_source ? "" : data.archive_file.exposures.output_base64sha256
+
+  function_name = "${module.labels.id}-exposures"
+  handler       = "exposures.handler"
+  memory_size   = var.lambda_exposures_memory_size
+  role          = aws_iam_role.exposures.arn
+  runtime       = "nodejs12.x"
+  tags          = module.labels.tags
+  timeout       = var.lambda_exposures_timeout
 
   depends_on = [aws_cloudwatch_log_group.exposures]
-
-  vpc_config {
-    security_group_ids = [module.lambda_sg.id]
-    subnet_ids         = module.vpc.private_subnets
-  }
 
   environment {
     variables = {
@@ -106,6 +105,11 @@ resource "aws_lambda_function" "exposures" {
     ignore_changes = [
       source_code_hash,
     ]
+  }
+
+  vpc_config {
+    security_group_ids = [module.lambda_sg.id]
+    subnet_ids         = module.vpc.private_subnets
   }
 }
 

--- a/lambda-settings.tf
+++ b/lambda-settings.tf
@@ -75,10 +75,10 @@ resource "aws_iam_role_policy_attachment" "settings_aws_managed_policy" {
 
 resource "aws_lambda_function" "settings" {
   # Default is to use the stub file, but we need to cater for S3 bucket file being the source
-  filename         = local.lambdas_using_s3_as_source ? null : "${path.module}/.zip/${module.labels.id}_settings.zip"
-  s3_bucket        = local.lambdas_using_s3_as_source ? var.lambdas_custom_s3_bucket : null
-  s3_key           = local.lambdas_using_s3_as_source ? var.lambda_settings_s3_key : null
-  source_code_hash = local.lambdas_using_s3_as_source ? "" : data.archive_file.settings.output_base64sha256
+  filename         = local.lambdas_use_s3_as_source ? null : "${path.module}/.zip/${module.labels.id}_settings.zip"
+  s3_bucket        = local.lambdas_use_s3_as_source ? var.lambdas_custom_s3_bucket : null
+  s3_key           = local.lambdas_use_s3_as_source ? var.lambda_settings_s3_key : null
+  source_code_hash = local.lambdas_use_s3_as_source ? "" : data.archive_file.settings.output_base64sha256
 
   function_name = "${module.labels.id}-settings"
   handler       = "settings.handler"

--- a/lambda-settings.tf
+++ b/lambda-settings.tf
@@ -74,22 +74,21 @@ resource "aws_iam_role_policy_attachment" "settings_aws_managed_policy" {
 }
 
 resource "aws_lambda_function" "settings" {
-  filename         = "${path.module}/.zip/${module.labels.id}_settings.zip"
-  function_name    = "${module.labels.id}-settings"
-  source_code_hash = data.archive_file.settings.output_base64sha256
-  role             = aws_iam_role.settings.arn
-  runtime          = "nodejs12.x"
-  handler          = "settings.handler"
-  memory_size      = var.lambda_settings_memory_size
-  timeout          = var.lambda_settings_timeout
-  tags             = module.labels.tags
+  # Default is to use the stub file, but we need to cater for S3 bucket file being the source
+  filename         = local.lambdas_using_s3_as_source ? null : "${path.module}/.zip/${module.labels.id}_settings.zip"
+  s3_bucket        = local.lambdas_using_s3_as_source ? var.lambdas_custom_s3_bucket : null
+  s3_key           = local.lambdas_using_s3_as_source ? var.lambda_settings_s3_key : null
+  source_code_hash = local.lambdas_using_s3_as_source ? "" : data.archive_file.settings.output_base64sha256
+
+  function_name = "${module.labels.id}-settings"
+  handler       = "settings.handler"
+  memory_size   = var.lambda_settings_memory_size
+  role          = aws_iam_role.settings.arn
+  runtime       = "nodejs12.x"
+  tags          = module.labels.tags
+  timeout       = var.lambda_settings_timeout
 
   depends_on = [aws_cloudwatch_log_group.settings]
-
-  vpc_config {
-    security_group_ids = [module.lambda_sg.id]
-    subnet_ids         = module.vpc.private_subnets
-  }
 
   environment {
     variables = {
@@ -102,6 +101,11 @@ resource "aws_lambda_function" "settings" {
     ignore_changes = [
       source_code_hash,
     ]
+  }
+
+  vpc_config {
+    security_group_ids = [module.lambda_sg.id]
+    subnet_ids         = module.vpc.private_subnets
   }
 }
 

--- a/lambda-sms.tf
+++ b/lambda-sms.tf
@@ -30,6 +30,8 @@ module "sms" {
   kms_reader_arns                            = [aws_kms_key.sqs.arn]
   log_retention_days                         = var.logs_retention_days
   memory_size                                = var.lambda_sms_memory_size
+  s3_bucket                                  = var.lambdas_custom_s3_bucket
+  s3_key                                     = var.lambda_sms_s3_key
   security_group_ids                         = [module.lambda_sg.id]
   sqs_queue_arns_to_consume_from             = [aws_sqs_queue.sms.arn]
   subnet_ids                                 = module.vpc.private_subnets

--- a/lambda-stats.tf
+++ b/lambda-stats.tf
@@ -75,22 +75,21 @@ resource "aws_iam_role_policy_attachment" "stats_aws_managed_policy" {
 }
 
 resource "aws_lambda_function" "stats" {
-  filename         = "${path.module}/.zip/${module.labels.id}_stats.zip"
-  function_name    = "${module.labels.id}-stats"
-  source_code_hash = data.archive_file.stats.output_base64sha256
-  role             = aws_iam_role.stats.arn
-  runtime          = "nodejs12.x"
-  handler          = "stats.handler"
-  memory_size      = var.lambda_stats_memory_size
-  timeout          = var.lambda_stats_timeout
-  tags             = module.labels.tags
+  # Default is to use the stub file, but we need to cater for S3 bucket file being the source
+  filename         = local.lambdas_using_s3_as_source ? null : "${path.module}/.zip/${module.labels.id}_stats.zip"
+  s3_bucket        = local.lambdas_using_s3_as_source ? var.lambdas_custom_s3_bucket : null
+  s3_key           = local.lambdas_using_s3_as_source ? var.lambda_stats_s3_key : null
+  source_code_hash = local.lambdas_using_s3_as_source ? "" : data.archive_file.stats.output_base64sha256
+
+  function_name = "${module.labels.id}-stats"
+  handler       = "stats.handler"
+  memory_size   = var.lambda_stats_memory_size
+  role          = aws_iam_role.stats.arn
+  runtime       = "nodejs12.x"
+  tags          = module.labels.tags
+  timeout       = var.lambda_stats_timeout
 
   depends_on = [aws_cloudwatch_log_group.stats]
-
-  vpc_config {
-    security_group_ids = [module.lambda_sg.id]
-    subnet_ids         = module.vpc.private_subnets
-  }
 
   environment {
     variables = {
@@ -103,6 +102,11 @@ resource "aws_lambda_function" "stats" {
     ignore_changes = [
       source_code_hash,
     ]
+  }
+
+  vpc_config {
+    security_group_ids = [module.lambda_sg.id]
+    subnet_ids         = module.vpc.private_subnets
   }
 }
 

--- a/lambda-stats.tf
+++ b/lambda-stats.tf
@@ -76,10 +76,10 @@ resource "aws_iam_role_policy_attachment" "stats_aws_managed_policy" {
 
 resource "aws_lambda_function" "stats" {
   # Default is to use the stub file, but we need to cater for S3 bucket file being the source
-  filename         = local.lambdas_using_s3_as_source ? null : "${path.module}/.zip/${module.labels.id}_stats.zip"
-  s3_bucket        = local.lambdas_using_s3_as_source ? var.lambdas_custom_s3_bucket : null
-  s3_key           = local.lambdas_using_s3_as_source ? var.lambda_stats_s3_key : null
-  source_code_hash = local.lambdas_using_s3_as_source ? "" : data.archive_file.stats.output_base64sha256
+  filename         = local.lambdas_use_s3_as_source ? null : "${path.module}/.zip/${module.labels.id}_stats.zip"
+  s3_bucket        = local.lambdas_use_s3_as_source ? var.lambdas_custom_s3_bucket : null
+  s3_key           = local.lambdas_use_s3_as_source ? var.lambda_stats_s3_key : null
+  source_code_hash = local.lambdas_use_s3_as_source ? "" : data.archive_file.stats.output_base64sha256
 
   function_name = "${module.labels.id}-stats"
   handler       = "stats.handler"

--- a/lambda-token.tf
+++ b/lambda-token.tf
@@ -73,10 +73,10 @@ resource "aws_iam_role_policy_attachment" "token_aws_managed_policy" {
 
 resource "aws_lambda_function" "token" {
   # Default is to use the stub file, but we need to cater for S3 bucket file being the source
-  filename         = local.lambdas_using_s3_as_source ? null : "${path.module}/.zip/${module.labels.id}_token.zip"
-  s3_bucket        = local.lambdas_using_s3_as_source ? var.lambdas_custom_s3_bucket : null
-  s3_key           = local.lambdas_using_s3_as_source ? var.lambda_token_s3_key : null
-  source_code_hash = local.lambdas_using_s3_as_source ? "" : data.archive_file.token.output_base64sha256
+  filename         = local.lambdas_use_s3_as_source ? null : "${path.module}/.zip/${module.labels.id}_token.zip"
+  s3_bucket        = local.lambdas_use_s3_as_source ? var.lambdas_custom_s3_bucket : null
+  s3_key           = local.lambdas_use_s3_as_source ? var.lambda_token_s3_key : null
+  source_code_hash = local.lambdas_use_s3_as_source ? "" : data.archive_file.token.output_base64sha256
 
   function_name = "${module.labels.id}-token"
   handler       = "token.handler"

--- a/lambda-token.tf
+++ b/lambda-token.tf
@@ -72,22 +72,21 @@ resource "aws_iam_role_policy_attachment" "token_aws_managed_policy" {
 }
 
 resource "aws_lambda_function" "token" {
-  filename         = "${path.module}/.zip/${module.labels.id}_token.zip"
-  function_name    = "${module.labels.id}-token"
-  source_code_hash = data.archive_file.token.output_base64sha256
-  role             = aws_iam_role.token.arn
-  runtime          = "nodejs12.x"
-  handler          = "token.handler"
-  memory_size      = var.lambda_token_memory_size
-  timeout          = var.lambda_token_timeout
-  tags             = module.labels.tags
+  # Default is to use the stub file, but we need to cater for S3 bucket file being the source
+  filename         = local.lambdas_using_s3_as_source ? null : "${path.module}/.zip/${module.labels.id}_token.zip"
+  s3_bucket        = local.lambdas_using_s3_as_source ? var.lambdas_custom_s3_bucket : null
+  s3_key           = local.lambdas_using_s3_as_source ? var.lambda_token_s3_key : null
+  source_code_hash = local.lambdas_using_s3_as_source ? "" : data.archive_file.token.output_base64sha256
+
+  function_name = "${module.labels.id}-token"
+  handler       = "token.handler"
+  memory_size   = var.lambda_token_memory_size
+  role          = aws_iam_role.token.arn
+  runtime       = "nodejs12.x"
+  tags          = module.labels.tags
+  timeout       = var.lambda_token_timeout
 
   depends_on = [aws_cloudwatch_log_group.token]
-
-  vpc_config {
-    security_group_ids = [module.lambda_sg.id]
-    subnet_ids         = module.vpc.private_subnets
-  }
 
   environment {
     variables = {
@@ -101,4 +100,11 @@ resource "aws_lambda_function" "token" {
       source_code_hash,
     ]
   }
+
+  vpc_config {
+    security_group_ids = [module.lambda_sg.id]
+    subnet_ids         = module.vpc.private_subnets
+  }
+
+
 }

--- a/lambda-upload.tf
+++ b/lambda-upload.tf
@@ -23,6 +23,8 @@ module "upload" {
   handler                        = "upload.handler"
   log_retention_days             = var.logs_retention_days
   memory_size                    = var.lambda_upload_memory_size
+  s3_bucket                      = var.lambdas_custom_s3_bucket
+  s3_key                         = var.lambda_upload_s3_key
   security_group_ids             = [module.lambda_sg.id]
   subnet_ids                     = module.vpc.private_subnets
   tags                           = module.labels.tags

--- a/locals.tf
+++ b/locals.tf
@@ -48,6 +48,11 @@ locals {
   lambda_download_count                     = contains(var.optional_lambdas_to_include, "download") ? 1 : 0
   lambda_upload_count                       = contains(var.optional_lambdas_to_include, "upload") ? 1 : 0
 
+  # Lambdas using S3 bucket as source - is a global value, so will apply to all of them
+  # If set will assume the S3 key is provided and that a file exists in the bucket
+  # Since this is an override, we do not manage this bucket or access to the same
+  lambdas_using_s3_as_source = var.lambdas_custom_s3_bucket != ""
+
   # RDS enhanced monitoring count
   rds_enhanced_monitoring_enabled_count = var.rds_enhanced_monitoring_interval > 0 ? 1 : 0
 

--- a/locals.tf
+++ b/locals.tf
@@ -51,7 +51,7 @@ locals {
   # Lambdas using S3 bucket as source - is a global value, so will apply to all of them
   # If set will assume the S3 key is provided and that a file exists in the bucket
   # Since this is an override, we do not manage this bucket or access to the same
-  lambdas_using_s3_as_source = var.lambdas_custom_s3_bucket != ""
+  lambdas_use_s3_as_source = var.lambdas_custom_s3_bucket != ""
 
   # RDS enhanced monitoring count
   rds_enhanced_monitoring_enabled_count = var.rds_enhanced_monitoring_interval > 0 ? 1 : 0

--- a/modules/lambda/main.tf
+++ b/modules/lambda/main.tf
@@ -67,6 +67,15 @@ variable "security_group_ids" {
   default = []
 }
 
+# Default is not to use it
+variable "s3_bucket" {
+  default = ""
+}
+
+variable "s3_key" {
+  default = ""
+}
+
 variable "sns_topic_arns_to_consume_from" {
   default = []
 }
@@ -103,6 +112,7 @@ locals {
   aws_managed_policy_arn_to_attach_count = var.enable && var.aws_managed_policy_arn_to_attach != "" ? 1 : 0
   enable_cloudwatch_schedule_count       = var.enable && var.cloudwatch_schedule_expression != "" ? 1 : 0
   enable_count                           = var.enable ? 1 : 0
+  use_s3_as_source                       = var.s3_bucket != "" && var.s3_key != ""
 }
 
 data "archive_file" "this" {
@@ -264,15 +274,18 @@ resource "aws_iam_role_policy_attachment" "this" {
 resource "aws_lambda_function" "this" {
   count = local.enable_count
 
-  filename         = format("%s/.zip/%s.zip", path.module, var.name)
-  function_name    = var.name
-  handler          = var.handler
-  memory_size      = var.memory_size
-  role             = aws_iam_role.this[0].arn
-  runtime          = var.runtime
-  source_code_hash = data.archive_file.this.output_base64sha256
-  tags             = var.tags
-  timeout          = var.timeout
+  filename         = local.use_s3_as_source ? null : format("%s/.zip/%s.zip", path.module, var.name)
+  s3_bucket        = local.use_s3_as_source ? var.s3_bucket : null
+  s3_key           = local.use_s3_as_source ? var.s3_key : null
+  source_code_hash = local.use_s3_as_source ? null : data.archive_file.this.output_base64sha256
+
+  function_name = var.name
+  handler       = var.handler
+  memory_size   = var.memory_size
+  role          = aws_iam_role.this[0].arn
+  runtime       = var.runtime
+  tags          = var.tags
+  timeout       = var.timeout
 
   depends_on = [aws_cloudwatch_log_group.this]
 

--- a/variables.tf
+++ b/variables.tf
@@ -327,11 +327,17 @@ variable "default_region" {
 variable "lambda_authorizer_memory_size" {
   default = 512 # Since this is on the hot path and we get faster CPUs with higher memory
 }
+variable "lambda_authorizer_s3_key" {
+  default = ""
+}
 variable "lambda_authorizer_timeout" {
   default = 15
 }
 variable "lambda_callback_memory_size" {
   default = 128
+}
+variable "lambda_callback_s3_key" {
+  default = ""
 }
 variable "lambda_callback_timeout" {
   default = 15
@@ -339,11 +345,17 @@ variable "lambda_callback_timeout" {
 variable "lambda_cso_memory_size" {
   default = 3008
 }
+variable "lambda_cso_s3_key" {
+  default = ""
+}
 variable "lambda_cso_timeout" {
   default = 900
 }
 variable "lambda_daily_registrations_reporter_memory_size" {
   default = 128
+}
+variable "lambda_daily_registrations_reporter_s3_key" {
+  default = ""
 }
 variable "lambda_daily_registrations_reporter_timeout" {
   default = 15
@@ -351,11 +363,17 @@ variable "lambda_daily_registrations_reporter_timeout" {
 variable "lambda_download_memory_size" {
   default = 128
 }
+variable "lambda_download_s3_key" {
+  default = ""
+}
 variable "lambda_download_timeout" {
   default = 15
 }
 variable "lambda_exposures_memory_size" {
   default = 128
+}
+variable "lambda_exposures_s3_key" {
+  default = ""
 }
 variable "lambda_exposures_timeout" {
   default = 15
@@ -366,11 +384,17 @@ variable "lambda_provisioned_concurrencies" {
 variable "lambda_settings_memory_size" {
   default = 128
 }
+variable "lambda_settings_s3_key" {
+  default = ""
+}
 variable "lambda_settings_timeout" {
   default = 15
 }
 variable "lambda_sms_memory_size" {
   default = 128
+}
+variable "lambda_sms_s3_key" {
+  default = ""
 }
 variable "lambda_sms_timeout" {
   default = 15
@@ -378,11 +402,17 @@ variable "lambda_sms_timeout" {
 variable "lambda_stats_memory_size" {
   default = 256
 }
+variable "lambda_stats_s3_key" {
+  default = ""
+}
 variable "lambda_stats_timeout" {
   default = 120
 }
 variable "lambda_token_memory_size" {
   default = 128
+}
+variable "lambda_token_s3_key" {
+  default = ""
 }
 variable "lambda_token_timeout" {
   default = 15
@@ -390,8 +420,15 @@ variable "lambda_token_timeout" {
 variable "lambda_upload_memory_size" {
   default = 128
 }
+variable "lambda_upload_s3_key" {
+  default = ""
+}
 variable "lambda_upload_timeout" {
   default = 15
+}
+variable "lambdas_custom_s3_bucket" {
+  description = "Lambdas custom S3 bucket, overrides the default local file usage, assumes we can get content from the bucket as this module does not manage this bucket"
+  default     = ""
 }
 variable "native_regions" {
   default = ""


### PR DESCRIPTION
See https://github.com/covidgreen/covid-green-infra/issues/12

Will include extra vars
```
lambdas_custom_s3_bucket
lambda_LAMBDA-NAME_s3_key
```
all defaulted to empty which will mean we do not use S3

If the `lambdas_custom_s3_bucket` var is set we will use S3 and assume you have set all the lambdas `s3_key` var

We also do not manage this S3 bucket - assumes it is managed outside this content and therefore do not do anything to allow the lambda to get the source from the S3 bucket
