### PR TITLE
Dev -> current

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 
 ## [Unreleased]
+- Fixed: Altered the ECS image so the custom vars are just for the image and do not include the tag, we append the tag if using a custom image using the tag var
 - Fixed: Fixed the "bastion_amazon_ssm_managed_instance_core" aws_iam_role_policy_attachment (Incorrect casing in name), this will result in a Terraform apply failure when applied, can run a second time to fix
 - Fixed: Removed RDS admin user access where not needed
 - Added: Added "verify" secret and changed "jwt_issuer" and "certificate_audience" parameters to support third party key server

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+
 ## [Unreleased]
+- Fixed: Fixed the "bastion_amazon_ssm_managed_instance_core" aws_iam_role_policy_attachment (Incorrect casing in name), this will result in a Terraform apply failure when applied, can run a second time to fix
+- Fixed: Removed RDS admin user access where not needed
 - Added: Added "verify" secret and changed "jwt_issuer" and "certificate_audience" parameters to support third party key server
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 
 ## [Unreleased]
+- Added: Added option to send callback notifications using email via an SNS topic - subscription will not be automated
 - Fixed: Altered the ECS image so the custom vars are just for the image and do not include the tag, we append the tag if using a custom image using the tag var
 - Fixed: Fixed the "bastion_amazon_ssm_managed_instance_core" aws_iam_role_policy_attachment (Incorrect casing in name), this will result in a Terraform apply failure when applied, can run a second time to fix
 - Fixed: Removed RDS admin user access where not needed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 
 ## [Unreleased]
+
+
+## [v0.1.3] 2020-08-25
 - Added: Option to use an S3 bucket as the source for lambdas, will be a global setting and we do not manage this bucket as this is a non default option
 - Added: Added option to send callback notifications using email via an SNS topic - subscription will not be automated
 - Fixed: Altered the ECS image so the custom vars are just for the image and do not include the tag, we append the tag if using a custom image using the tag var

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 
 ## [Unreleased]
+- Added: Option to use an S3 bucket as the source for lambdas, will be a global setting and we do not manage this bucket as this is a non default option
 - Added: Added option to send callback notifications using email via an SNS topic - subscription will not be automated
 - Fixed: Altered the ECS image so the custom vars are just for the image and do not include the tag, we append the tag if using a custom image using the tag var
 - Fixed: Fixed the "bastion_amazon_ssm_managed_instance_core" aws_iam_role_policy_attachment (Incorrect casing in name), this will result in a Terraform apply failure when applied, can run a second time to fix

--- a/bastion.tf
+++ b/bastion.tf
@@ -110,7 +110,7 @@ resource "aws_iam_role" "bastion" {
   })
 }
 
-resource "aws_iam_role_policy_attachment" "bastion_amazon_ssm_managed_Instance_core" {
+resource "aws_iam_role_policy_attachment" "bastion_amazon_ssm_managed_instance_core" {
   count      = local.bastion_enabled_count
   policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
   role       = aws_iam_role.bastion[0].name

--- a/docs/secrets-parameters.md
+++ b/docs/secrets-parameters.md
@@ -38,6 +38,9 @@ Parameters are managed by the Terraform content.
 	- daily_registrations_reporter_email_subject
 	- daily_registrations_reporter_sns_arn
 
+### Granting access to secrets and parameters
+When adding a new secret or parameter you will need to explicily add to the workload policies
+
 
 ### Generation of Secret Values
 

--- a/ecs_api.tf
+++ b/ecs_api.tf
@@ -110,10 +110,10 @@ resource "aws_ecs_task_definition" "api" {
 
   container_definitions = templatefile(format("%s/templates/api_service_task_definition.tpl", path.module),
     {
-      api_image_uri        = local.ecs_api_image_uri
+      api_image_uri        = local.ecs_api_image
       aws_region           = var.aws_region
       config_var_prefix    = local.config_var_prefix
-      migrations_image_uri = local.ecs_migrations_image_uri
+      migrations_image_uri = local.ecs_migrations_image
       listening_port       = var.api_listening_port
       logs_service_name    = aws_cloudwatch_log_group.api.name
       log_group_region     = var.aws_region

--- a/ecs_api.tf
+++ b/ecs_api.tf
@@ -29,7 +29,7 @@ resource "aws_iam_role" "api_ecs_task_role" {
 
 data "aws_iam_policy_document" "api_ecs_task_policy" {
   statement {
-    actions = ["ssm:GetParameter", "secretsmanager:GetSecretValue"]
+    actions = ["ssm:GetParameter"]
     resources = [
       aws_ssm_parameter.api_host.arn,
       aws_ssm_parameter.api_port.arn,
@@ -54,11 +54,16 @@ data "aws_iam_policy_document" "api_ecs_task_policy" {
       aws_ssm_parameter.security_refresh_token_expiry.arn,
       aws_ssm_parameter.security_token_lifetime_mins.arn,
       aws_ssm_parameter.security_verify_rate_limit_secs.arn,
-      aws_ssm_parameter.upload_token_lifetime_mins.arn,
+      aws_ssm_parameter.upload_token_lifetime_mins.arn
+    ]
+  }
+
+  statement {
+    actions = ["secretsmanager:GetSecretValue"]
+    resources = [
       data.aws_secretsmanager_secret_version.device_check.arn,
       data.aws_secretsmanager_secret_version.encrypt.arn,
       data.aws_secretsmanager_secret_version.jwt.arn,
-      data.aws_secretsmanager_secret_version.rds.arn,
       data.aws_secretsmanager_secret_version.rds_read_write_create.arn,
       data.aws_secretsmanager_secret_version.verify.arn
     ]

--- a/ecs_push.tf
+++ b/ecs_push.tf
@@ -14,7 +14,7 @@ data "aws_iam_policy_document" "push_ecs_assume_role_policy" {
 
 data "aws_iam_policy_document" "push_ecs_task_policy" {
   statement {
-    actions = ["ssm:GetParameter", "secretsmanager:GetSecretValue"]
+    actions = ["ssm:GetParameter"]
     resources = [
       aws_ssm_parameter.cors_origin.arn,
       aws_ssm_parameter.db_database.arn,
@@ -29,9 +29,14 @@ data "aws_iam_policy_document" "push_ecs_task_policy" {
       aws_ssm_parameter.security_code_charset.arn,
       aws_ssm_parameter.security_code_length.arn,
       aws_ssm_parameter.security_code_lifetime_mins.arn,
-      aws_ssm_parameter.sms_url.arn,
+      aws_ssm_parameter.sms_url.arn
+    ]
+  }
+
+  statement {
+    actions = ["secretsmanager:GetSecretValue"]
+    resources = [
       data.aws_secretsmanager_secret_version.jwt.arn,
-      data.aws_secretsmanager_secret_version.rds.arn,
       data.aws_secretsmanager_secret_version.rds_read_write.arn
     ]
   }

--- a/ecs_push.tf
+++ b/ecs_push.tf
@@ -97,7 +97,7 @@ resource "aws_ecs_task_definition" "push" {
     {
       aws_region        = var.aws_region
       config_var_prefix = local.config_var_prefix
-      image_uri         = local.ecs_push_image_uri
+      image_uri         = local.ecs_push_image
       listening_port    = var.push_listening_port
       logs_service_name = aws_cloudwatch_log_group.push.name
       log_group_region  = var.aws_region

--- a/lambda-callback.tf
+++ b/lambda-callback.tf
@@ -8,11 +8,28 @@ data "aws_iam_policy_document" "callback_policy" {
   statement {
     actions = [
       "s3:*",
-      "secretsmanager:GetSecretValue",
-      "ssm:GetParameter",
       "sqs:*"
     ]
     resources = ["*"]
+  }
+
+  statement {
+    actions = ["ssm:GetParameter"]
+    resources = [
+      aws_ssm_parameter.callback_url.arn,
+      aws_ssm_parameter.db_database.arn,
+      aws_ssm_parameter.db_host.arn,
+      aws_ssm_parameter.db_port.arn,
+      aws_ssm_parameter.db_ssl.arn
+    ]
+  }
+
+  statement {
+    actions = ["secretsmanager:GetSecretValue"]
+    resources = concat(
+      [data.aws_secretsmanager_secret_version.rds_read_write.arn],
+      data.aws_secretsmanager_secret_version.cct.*.arn
+    )
   }
 
   statement {
@@ -31,7 +48,7 @@ data "aws_iam_policy_document" "callback_assume_role" {
       type = "Service"
 
       identifiers = [
-        "lambda.amazonaws.com",
+        "lambda.amazonaws.com"
       ]
     }
   }

--- a/lambda-callback.tf
+++ b/lambda-callback.tf
@@ -103,22 +103,21 @@ resource "aws_iam_role_policy_attachment" "callback_aws_managed_policy" {
 }
 
 resource "aws_lambda_function" "callback" {
-  filename         = "${path.module}/.zip/${module.labels.id}_callback.zip"
-  function_name    = "${module.labels.id}-callback"
-  source_code_hash = data.archive_file.callback.output_base64sha256
-  role             = aws_iam_role.callback.arn
-  runtime          = "nodejs12.x"
-  handler          = "callback.handler"
-  memory_size      = var.lambda_callback_memory_size
-  timeout          = var.lambda_callback_timeout
-  tags             = module.labels.tags
+  # Default is to use the stub file, but we need to cater for S3 bucket file being the source
+  filename         = local.lambdas_use_s3_as_source ? null : "${path.module}/.zip/${module.labels.id}_callback.zip"
+  s3_bucket        = local.lambdas_use_s3_as_source ? var.lambdas_custom_s3_bucket : null
+  s3_key           = local.lambdas_use_s3_as_source ? var.lambda_callback_s3_key : null
+  source_code_hash = local.lambdas_use_s3_as_source ? "" : data.archive_file.callback.output_base64sha256
+
+  function_name = "${module.labels.id}-callback"
+  handler       = "callback.handler"
+  memory_size   = var.lambda_callback_memory_size
+  role          = aws_iam_role.callback.arn
+  runtime       = "nodejs12.x"
+  tags          = module.labels.tags
+  timeout       = var.lambda_callback_timeout
 
   depends_on = [aws_cloudwatch_log_group.callback]
-
-  vpc_config {
-    security_group_ids = [module.lambda_sg.id]
-    subnet_ids         = module.vpc.private_subnets
-  }
 
   environment {
     variables = {
@@ -131,6 +130,11 @@ resource "aws_lambda_function" "callback" {
     ignore_changes = [
       source_code_hash,
     ]
+  }
+
+  vpc_config {
+    security_group_ids = [module.lambda_sg.id]
+    subnet_ids         = module.vpc.private_subnets
   }
 }
 

--- a/lambda-callback.tf
+++ b/lambda-callback.tf
@@ -36,8 +36,17 @@ data "aws_iam_policy_document" "callback_policy" {
   }
 
   statement {
-    actions = ["kms:*"]
+    actions = [
+      "kms:Decrypt",
+      "kms:DescribeKey",
+      "kms:Encrypt",
+      "kms:GenerateDataKey",
+      "kms:GenerateDataKey*",
+      "kms:GetPublicKey",
+      "kms:ReEncrypt*"
+    ]
     resources = [
+      aws_kms_key.sns.arn,
       aws_kms_key.sqs.arn
     ]
   }

--- a/lambda-cso.tf
+++ b/lambda-cso.tf
@@ -6,12 +6,26 @@ data "archive_file" "cso" {
 
 data "aws_iam_policy_document" "cso_policy" {
   statement {
-    actions = [
-      "s3:*",
-      "secretsmanager:GetSecretValue",
-      "ssm:GetParameter"
-    ]
+    actions   = ["s3:*"]
     resources = ["*"]
+  }
+
+  statement {
+    actions = ["ssm:GetParameter"]
+    resources = [
+      aws_ssm_parameter.db_database.arn,
+      aws_ssm_parameter.db_host.arn,
+      aws_ssm_parameter.db_port.arn,
+      aws_ssm_parameter.db_ssl.arn
+    ]
+  }
+
+  statement {
+    actions = ["secretsmanager:GetSecretValue"]
+    resources = concat(
+      [data.aws_secretsmanager_secret_version.rds_read_write.arn],
+      data.aws_secretsmanager_secret_version.cso.*.arn
+    )
   }
 }
 
@@ -23,7 +37,7 @@ data "aws_iam_policy_document" "cso_assume_role" {
       type = "Service"
 
       identifiers = [
-        "lambda.amazonaws.com",
+        "lambda.amazonaws.com"
       ]
     }
   }

--- a/lambda-daily-registrations-reporter.tf
+++ b/lambda-daily-registrations-reporter.tf
@@ -22,7 +22,7 @@ module "daily_registrations_reporter" {
     aws_ssm_parameter.daily_registrations_reporter_email_subject.*.arn,
     aws_ssm_parameter.daily_registrations_reporter_sns_arn.*.arn
   )
-  aws_secret_arns                = [data.aws_secretsmanager_secret_version.rds.arn, data.aws_secretsmanager_secret_version.rds_read_write.arn]
+  aws_secret_arns                = [data.aws_secretsmanager_secret_version.rds_read_write.arn]
   cloudwatch_schedule_expression = var.daily_registrations_reporter_schedule
   config_var_prefix              = local.config_var_prefix
   handler                        = "reporter.handler"

--- a/lambda-daily-registrations-reporter.tf
+++ b/lambda-daily-registrations-reporter.tf
@@ -29,6 +29,8 @@ module "daily_registrations_reporter" {
   kms_writer_arns                = [aws_kms_key.sns.arn]
   log_retention_days             = var.logs_retention_days
   memory_size                    = var.lambda_daily_registrations_reporter_memory_size
+  s3_bucket                      = var.lambdas_custom_s3_bucket
+  s3_key                         = var.lambda_daily_registrations_reporter_s3_key
   security_group_ids             = [module.lambda_sg.id]
   sns_topic_arns_to_publish_to   = aws_sns_topic.daily_registrations_reporter.*.arn
   subnet_ids                     = module.vpc.private_subnets

--- a/lambda-download.tf
+++ b/lambda-download.tf
@@ -23,6 +23,8 @@ module "download" {
   handler                        = "download.handler"
   log_retention_days             = var.logs_retention_days
   memory_size                    = var.lambda_download_memory_size
+  s3_bucket                      = var.lambdas_custom_s3_bucket
+  s3_key                         = var.lambda_download_s3_key
   security_group_ids             = [module.lambda_sg.id]
   subnet_ids                     = module.vpc.private_subnets
   tags                           = module.labels.tags

--- a/lambda-download.tf
+++ b/lambda-download.tf
@@ -17,7 +17,7 @@ module "download" {
     aws_ssm_parameter.db_reader_host.arn,
     aws_ssm_parameter.db_ssl.arn
   ]
-  aws_secret_arns                = concat([data.aws_secretsmanager_secret_version.rds.arn, data.aws_secretsmanager_secret_version.rds_read_write.arn], data.aws_secretsmanager_secret_version.interop.*.arn)
+  aws_secret_arns                = concat([data.aws_secretsmanager_secret_version.rds_read_write.arn], data.aws_secretsmanager_secret_version.interop.*.arn)
   cloudwatch_schedule_expression = var.download_schedule
   config_var_prefix              = local.config_var_prefix
   handler                        = "download.handler"

--- a/lambda-exposures.tf
+++ b/lambda-exposures.tf
@@ -7,11 +7,31 @@ data "archive_file" "exposures" {
 data "aws_iam_policy_document" "exposures_policy" {
   statement {
     actions = [
-      "s3:*",
-      "secretsmanager:GetSecretValue",
-      "ssm:GetParameter"
+      "s3:*"
     ]
     resources = ["*"]
+  }
+
+  statement {
+    actions = ["ssm:GetParameter"]
+    resources = [
+      aws_ssm_parameter.app_bundle_id.arn,
+      aws_ssm_parameter.db_database.arn,
+      aws_ssm_parameter.db_host.arn,
+      aws_ssm_parameter.db_port.arn,
+      aws_ssm_parameter.db_ssl.arn,
+      aws_ssm_parameter.default_region.arn,
+      aws_ssm_parameter.native_regions.arn,
+      aws_ssm_parameter.s3_assets_bucket.arn
+    ]
+  }
+
+  statement {
+    actions = ["secretsmanager:GetSecretValue"]
+    resources = [
+      data.aws_secretsmanager_secret_version.exposures.arn,
+      data.aws_secretsmanager_secret_version.rds_read_write.arn
+    ]
   }
 }
 
@@ -23,7 +43,7 @@ data "aws_iam_policy_document" "exposures_assume_role" {
       type = "Service"
 
       identifiers = [
-        "lambda.amazonaws.com",
+        "lambda.amazonaws.com"
       ]
     }
   }

--- a/lambda-exposures.tf
+++ b/lambda-exposures.tf
@@ -78,22 +78,21 @@ resource "aws_iam_role_policy_attachment" "exposures_aws_managed_policy" {
 }
 
 resource "aws_lambda_function" "exposures" {
-  filename         = "${path.module}/.zip/${module.labels.id}_exposures.zip"
-  function_name    = "${module.labels.id}-exposures"
-  source_code_hash = data.archive_file.exposures.output_base64sha256
-  role             = aws_iam_role.exposures.arn
-  runtime          = "nodejs12.x"
-  handler          = "exposures.handler"
-  memory_size      = var.lambda_exposures_memory_size
-  timeout          = var.lambda_exposures_timeout
-  tags             = module.labels.tags
+  # Default is to use the stub file, but we need to cater for S3 bucket file being the source
+  filename         = local.lambdas_use_s3_as_source ? null : "${path.module}/.zip/${module.labels.id}_exposures.zip"
+  s3_bucket        = local.lambdas_use_s3_as_source ? var.lambdas_custom_s3_bucket : null
+  s3_key           = local.lambdas_use_s3_as_source ? var.lambda_exposures_s3_key : null
+  source_code_hash = local.lambdas_use_s3_as_source ? "" : data.archive_file.exposures.output_base64sha256
+
+  function_name = "${module.labels.id}-exposures"
+  handler       = "exposures.handler"
+  memory_size   = var.lambda_exposures_memory_size
+  role          = aws_iam_role.exposures.arn
+  runtime       = "nodejs12.x"
+  tags          = module.labels.tags
+  timeout       = var.lambda_exposures_timeout
 
   depends_on = [aws_cloudwatch_log_group.exposures]
-
-  vpc_config {
-    security_group_ids = [module.lambda_sg.id]
-    subnet_ids         = module.vpc.private_subnets
-  }
 
   environment {
     variables = {
@@ -106,6 +105,11 @@ resource "aws_lambda_function" "exposures" {
     ignore_changes = [
       source_code_hash,
     ]
+  }
+
+  vpc_config {
+    security_group_ids = [module.lambda_sg.id]
+    subnet_ids         = module.vpc.private_subnets
   }
 }
 

--- a/lambda-settings.tf
+++ b/lambda-settings.tf
@@ -74,22 +74,21 @@ resource "aws_iam_role_policy_attachment" "settings_aws_managed_policy" {
 }
 
 resource "aws_lambda_function" "settings" {
-  filename         = "${path.module}/.zip/${module.labels.id}_settings.zip"
-  function_name    = "${module.labels.id}-settings"
-  source_code_hash = data.archive_file.settings.output_base64sha256
-  role             = aws_iam_role.settings.arn
-  runtime          = "nodejs12.x"
-  handler          = "settings.handler"
-  memory_size      = var.lambda_settings_memory_size
-  timeout          = var.lambda_settings_timeout
-  tags             = module.labels.tags
+  # Default is to use the stub file, but we need to cater for S3 bucket file being the source
+  filename         = local.lambdas_use_s3_as_source ? null : "${path.module}/.zip/${module.labels.id}_settings.zip"
+  s3_bucket        = local.lambdas_use_s3_as_source ? var.lambdas_custom_s3_bucket : null
+  s3_key           = local.lambdas_use_s3_as_source ? var.lambda_settings_s3_key : null
+  source_code_hash = local.lambdas_use_s3_as_source ? "" : data.archive_file.settings.output_base64sha256
+
+  function_name = "${module.labels.id}-settings"
+  handler       = "settings.handler"
+  memory_size   = var.lambda_settings_memory_size
+  role          = aws_iam_role.settings.arn
+  runtime       = "nodejs12.x"
+  tags          = module.labels.tags
+  timeout       = var.lambda_settings_timeout
 
   depends_on = [aws_cloudwatch_log_group.settings]
-
-  vpc_config {
-    security_group_ids = [module.lambda_sg.id]
-    subnet_ids         = module.vpc.private_subnets
-  }
 
   environment {
     variables = {
@@ -102,6 +101,11 @@ resource "aws_lambda_function" "settings" {
     ignore_changes = [
       source_code_hash,
     ]
+  }
+
+  vpc_config {
+    security_group_ids = [module.lambda_sg.id]
+    subnet_ids         = module.vpc.private_subnets
   }
 }
 

--- a/lambda-settings.tf
+++ b/lambda-settings.tf
@@ -7,11 +7,27 @@ data "archive_file" "settings" {
 data "aws_iam_policy_document" "settings_policy" {
   statement {
     actions = [
-      "s3:*",
-      "secretsmanager:GetSecretValue",
-      "ssm:GetParameter"
+      "s3:*"
     ]
     resources = ["*"]
+  }
+
+  statement {
+    actions = ["ssm:GetParameter"]
+    resources = [
+      aws_ssm_parameter.db_database.arn,
+      aws_ssm_parameter.db_host.arn,
+      aws_ssm_parameter.db_port.arn,
+      aws_ssm_parameter.db_ssl.arn,
+      aws_ssm_parameter.s3_assets_bucket.arn
+    ]
+  }
+
+  statement {
+    actions = ["secretsmanager:GetSecretValue"]
+    resources = [
+      data.aws_secretsmanager_secret_version.rds_read_write.arn
+    ]
   }
 }
 
@@ -23,7 +39,7 @@ data "aws_iam_policy_document" "settings_assume_role" {
       type = "Service"
 
       identifiers = [
-        "lambda.amazonaws.com",
+        "lambda.amazonaws.com"
       ]
     }
   }

--- a/lambda-sms.tf
+++ b/lambda-sms.tf
@@ -30,6 +30,8 @@ module "sms" {
   kms_reader_arns                            = [aws_kms_key.sqs.arn]
   log_retention_days                         = var.logs_retention_days
   memory_size                                = var.lambda_sms_memory_size
+  s3_bucket                                  = var.lambdas_custom_s3_bucket
+  s3_key                                     = var.lambda_sms_s3_key
   security_group_ids                         = [module.lambda_sg.id]
   sqs_queue_arns_to_consume_from             = [aws_sqs_queue.sms.arn]
   subnet_ids                                 = module.vpc.private_subnets

--- a/lambda-sms.tf
+++ b/lambda-sms.tf
@@ -23,7 +23,7 @@ module "sms" {
     aws_ssm_parameter.sms_template.arn,
     aws_ssm_parameter.sms_url.arn
   ]
-  aws_secret_arns                            = concat([data.aws_secretsmanager_secret_version.rds.arn, data.aws_secretsmanager_secret_version.rds_read_write.arn], data.aws_secretsmanager_secret_version.sms.*.arn)
+  aws_secret_arns                            = concat([data.aws_secretsmanager_secret_version.rds_read_write.arn], data.aws_secretsmanager_secret_version.sms.*.arn)
   config_var_prefix                          = local.config_var_prefix
   enable_sns_publish_for_sms_without_a_topic = var.enable_sms_publishing_with_aws
   handler                                    = "sms.handler"

--- a/lambda-stats.tf
+++ b/lambda-stats.tf
@@ -75,22 +75,21 @@ resource "aws_iam_role_policy_attachment" "stats_aws_managed_policy" {
 }
 
 resource "aws_lambda_function" "stats" {
-  filename         = "${path.module}/.zip/${module.labels.id}_stats.zip"
-  function_name    = "${module.labels.id}-stats"
-  source_code_hash = data.archive_file.stats.output_base64sha256
-  role             = aws_iam_role.stats.arn
-  runtime          = "nodejs12.x"
-  handler          = "stats.handler"
-  memory_size      = var.lambda_stats_memory_size
-  timeout          = var.lambda_stats_timeout
-  tags             = module.labels.tags
+  # Default is to use the stub file, but we need to cater for S3 bucket file being the source
+  filename         = local.lambdas_use_s3_as_source ? null : "${path.module}/.zip/${module.labels.id}_stats.zip"
+  s3_bucket        = local.lambdas_use_s3_as_source ? var.lambdas_custom_s3_bucket : null
+  s3_key           = local.lambdas_use_s3_as_source ? var.lambda_stats_s3_key : null
+  source_code_hash = local.lambdas_use_s3_as_source ? "" : data.archive_file.stats.output_base64sha256
+
+  function_name = "${module.labels.id}-stats"
+  handler       = "stats.handler"
+  memory_size   = var.lambda_stats_memory_size
+  role          = aws_iam_role.stats.arn
+  runtime       = "nodejs12.x"
+  tags          = module.labels.tags
+  timeout       = var.lambda_stats_timeout
 
   depends_on = [aws_cloudwatch_log_group.stats]
-
-  vpc_config {
-    security_group_ids = [module.lambda_sg.id]
-    subnet_ids         = module.vpc.private_subnets
-  }
 
   environment {
     variables = {
@@ -103,6 +102,11 @@ resource "aws_lambda_function" "stats" {
     ignore_changes = [
       source_code_hash,
     ]
+  }
+
+  vpc_config {
+    security_group_ids = [module.lambda_sg.id]
+    subnet_ids         = module.vpc.private_subnets
   }
 }
 

--- a/lambda-stats.tf
+++ b/lambda-stats.tf
@@ -6,12 +6,29 @@ data "archive_file" "stats" {
 
 data "aws_iam_policy_document" "stats_policy" {
   statement {
-    actions = [
-      "s3:*",
-      "secretsmanager:GetSecretValue",
-      "ssm:GetParameter"
-    ]
+    actions   = ["s3:*"]
     resources = ["*"]
+  }
+
+  statement {
+    actions = ["ssm:GetParameter"]
+    resources = concat(
+      [
+        aws_ssm_parameter.db_database.arn,
+        aws_ssm_parameter.db_host.arn,
+        aws_ssm_parameter.db_port.arn,
+        aws_ssm_parameter.db_ssl.arn,
+        aws_ssm_parameter.s3_assets_bucket.arn
+      ],
+      aws_ssm_parameter.arcgis_url.*.arn
+    )
+  }
+
+  statement {
+    actions = ["secretsmanager:GetSecretValue"]
+    resources = [
+      data.aws_secretsmanager_secret_version.rds_read_write.arn
+    ]
   }
 }
 
@@ -23,7 +40,7 @@ data "aws_iam_policy_document" "stats_assume_role" {
       type = "Service"
 
       identifiers = [
-        "lambda.amazonaws.com",
+        "lambda.amazonaws.com"
       ]
     }
   }

--- a/lambda-token.tf
+++ b/lambda-token.tf
@@ -6,12 +6,26 @@ data "archive_file" "token" {
 
 data "aws_iam_policy_document" "token_policy" {
   statement {
-    actions = [
-      "s3:*",
-      "secretsmanager:GetSecretValue",
-      "ssm:GetParameter"
-    ]
+    actions   = ["s3:*"]
     resources = ["*"]
+  }
+
+  statement {
+    actions = ["ssm:GetParameter"]
+    resources = [
+      aws_ssm_parameter.db_database.arn,
+      aws_ssm_parameter.db_host.arn,
+      aws_ssm_parameter.db_port.arn,
+      aws_ssm_parameter.db_ssl.arn
+    ]
+  }
+
+  statement {
+    actions = ["secretsmanager:GetSecretValue"]
+    resources = [
+      data.aws_secretsmanager_secret_version.jwt.arn,
+      data.aws_secretsmanager_secret_version.rds_read_write.arn
+    ]
   }
 }
 
@@ -23,7 +37,7 @@ data "aws_iam_policy_document" "token_assume_role" {
       type = "Service"
 
       identifiers = [
-        "lambda.amazonaws.com",
+        "lambda.amazonaws.com"
       ]
     }
   }

--- a/lambda-token.tf
+++ b/lambda-token.tf
@@ -72,22 +72,21 @@ resource "aws_iam_role_policy_attachment" "token_aws_managed_policy" {
 }
 
 resource "aws_lambda_function" "token" {
-  filename         = "${path.module}/.zip/${module.labels.id}_token.zip"
-  function_name    = "${module.labels.id}-token"
-  source_code_hash = data.archive_file.token.output_base64sha256
-  role             = aws_iam_role.token.arn
-  runtime          = "nodejs12.x"
-  handler          = "token.handler"
-  memory_size      = var.lambda_token_memory_size
-  timeout          = var.lambda_token_timeout
-  tags             = module.labels.tags
+  # Default is to use the stub file, but we need to cater for S3 bucket file being the source
+  filename         = local.lambdas_use_s3_as_source ? null : "${path.module}/.zip/${module.labels.id}_token.zip"
+  s3_bucket        = local.lambdas_use_s3_as_source ? var.lambdas_custom_s3_bucket : null
+  s3_key           = local.lambdas_use_s3_as_source ? var.lambda_token_s3_key : null
+  source_code_hash = local.lambdas_use_s3_as_source ? "" : data.archive_file.token.output_base64sha256
+
+  function_name = "${module.labels.id}-token"
+  handler       = "token.handler"
+  memory_size   = var.lambda_token_memory_size
+  role          = aws_iam_role.token.arn
+  runtime       = "nodejs12.x"
+  tags          = module.labels.tags
+  timeout       = var.lambda_token_timeout
 
   depends_on = [aws_cloudwatch_log_group.token]
-
-  vpc_config {
-    security_group_ids = [module.lambda_sg.id]
-    subnet_ids         = module.vpc.private_subnets
-  }
 
   environment {
     variables = {
@@ -101,4 +100,11 @@ resource "aws_lambda_function" "token" {
       source_code_hash,
     ]
   }
+
+  vpc_config {
+    security_group_ids = [module.lambda_sg.id]
+    subnet_ids         = module.vpc.private_subnets
+  }
+
+
 }

--- a/lambda-upload.tf
+++ b/lambda-upload.tf
@@ -17,7 +17,7 @@ module "upload" {
     aws_ssm_parameter.db_reader_host.arn,
     aws_ssm_parameter.db_ssl.arn
   ]
-  aws_secret_arns                = concat([data.aws_secretsmanager_secret_version.rds.arn, data.aws_secretsmanager_secret_version.rds_read_write.arn], data.aws_secretsmanager_secret_version.interop.*.arn)
+  aws_secret_arns                = concat([data.aws_secretsmanager_secret_version.rds_read_write.arn], data.aws_secretsmanager_secret_version.interop.*.arn)
   cloudwatch_schedule_expression = var.upload_schedule
   config_var_prefix              = local.config_var_prefix
   handler                        = "upload.handler"

--- a/lambda-upload.tf
+++ b/lambda-upload.tf
@@ -23,6 +23,8 @@ module "upload" {
   handler                        = "upload.handler"
   log_retention_days             = var.logs_retention_days
   memory_size                    = var.lambda_upload_memory_size
+  s3_bucket                      = var.lambdas_custom_s3_bucket
+  s3_key                         = var.lambda_upload_s3_key
   security_group_ids             = [module.lambda_sg.id]
   subnet_ids                     = module.vpc.private_subnets
   tags                           = module.labels.tags

--- a/locals.tf
+++ b/locals.tf
@@ -15,9 +15,9 @@ locals {
   config_var_prefix = "${module.labels.id}-"
 
   # ECS image values
-  ecs_api_image_uri        = coalesce(var.api_image_repo_url, format("%s:%s", aws_ecr_repository.api.repository_url, var.api_image_tag))
-  ecs_migrations_image_uri = coalesce(var.migrations_image_repo_url, format("%s:%s", aws_ecr_repository.migrations.repository_url, var.migrations_image_tag))
-  ecs_push_image_uri       = coalesce(var.push_image_repo_url, format("%s:%s", aws_ecr_repository.push.repository_url, var.push_image_tag))
+  ecs_api_image        = format("%s:%s", coalesce(var.api_custom_image, aws_ecr_repository.api.repository_url), var.api_image_tag)
+  ecs_migrations_image = format("%s:%s", coalesce(var.migrations_custom_image, aws_ecr_repository.migrations.repository_url), var.migrations_image_tag)
+  ecs_push_image       = format("%s:%s", coalesce(var.push_custom_image, aws_ecr_repository.push.repository_url), var.push_image_tag)
 
   # Based on flag
   enable_certificates_count = var.enable_certificates ? 1 : 0

--- a/locals.tf
+++ b/locals.tf
@@ -20,6 +20,9 @@ locals {
   ecs_push_image       = format("%s:%s", coalesce(var.push_custom_image, aws_ecr_repository.push.repository_url), var.push_image_tag)
 
   # Based on flag
+  enable_callback_email_notifications_count = var.enable_callback && var.enable_callback_email_notifications ? 1 : 0
+
+  # Based on flag
   enable_certificates_count = var.enable_certificates ? 1 : 0
 
   # Based on flag

--- a/locals.tf
+++ b/locals.tf
@@ -48,6 +48,11 @@ locals {
   lambda_download_count                     = contains(var.optional_lambdas_to_include, "download") ? 1 : 0
   lambda_upload_count                       = contains(var.optional_lambdas_to_include, "upload") ? 1 : 0
 
+  # Lambdas using S3 bucket as source - is a global value, so will apply to all of them
+  # If set will assume the S3 key is provided and that a file exists in the bucket
+  # Since this is an override, we do not manage this bucket or access to the same
+  lambdas_use_s3_as_source = var.lambdas_custom_s3_bucket != ""
+
   # RDS enhanced monitoring count
   rds_enhanced_monitoring_enabled_count = var.rds_enhanced_monitoring_interval > 0 ? 1 : 0
 

--- a/modules/lambda/main.tf
+++ b/modules/lambda/main.tf
@@ -67,6 +67,15 @@ variable "security_group_ids" {
   default = []
 }
 
+# Default is not to use it
+variable "s3_bucket" {
+  default = ""
+}
+
+variable "s3_key" {
+  default = ""
+}
+
 variable "sns_topic_arns_to_consume_from" {
   default = []
 }
@@ -103,6 +112,7 @@ locals {
   aws_managed_policy_arn_to_attach_count = var.enable && var.aws_managed_policy_arn_to_attach != "" ? 1 : 0
   enable_cloudwatch_schedule_count       = var.enable && var.cloudwatch_schedule_expression != "" ? 1 : 0
   enable_count                           = var.enable ? 1 : 0
+  use_s3_as_source                       = var.s3_bucket != "" && var.s3_key != ""
 }
 
 data "archive_file" "this" {
@@ -264,15 +274,18 @@ resource "aws_iam_role_policy_attachment" "this" {
 resource "aws_lambda_function" "this" {
   count = local.enable_count
 
-  filename         = format("%s/.zip/%s.zip", path.module, var.name)
-  function_name    = var.name
-  handler          = var.handler
-  memory_size      = var.memory_size
-  role             = aws_iam_role.this[0].arn
-  runtime          = var.runtime
-  source_code_hash = data.archive_file.this.output_base64sha256
-  tags             = var.tags
-  timeout          = var.timeout
+  filename         = local.use_s3_as_source ? null : format("%s/.zip/%s.zip", path.module, var.name)
+  s3_bucket        = local.use_s3_as_source ? var.s3_bucket : null
+  s3_key           = local.use_s3_as_source ? var.s3_key : null
+  source_code_hash = local.use_s3_as_source ? null : data.archive_file.this.output_base64sha256
+
+  function_name = var.name
+  handler       = var.handler
+  memory_size   = var.memory_size
+  role          = aws_iam_role.this[0].arn
+  runtime       = var.runtime
+  tags          = var.tags
+  timeout       = var.timeout
 
   depends_on = [aws_cloudwatch_log_group.this]
 

--- a/parameters.tf
+++ b/parameters.tf
@@ -293,6 +293,15 @@ resource "aws_ssm_parameter" "arcgis_url" {
   tags      = module.labels.tags
 }
 
+resource "aws_ssm_parameter" "callback_email_notifications_sns_arn" {
+  count     = local.enable_callback_email_notifications_count
+  overwrite = true
+  name      = "${local.config_var_prefix}callback_email_notifications_sns_arn"
+  type      = "String"
+  value     = join("", aws_sns_topic.callback_email_notifications.*.arn)
+  tags      = module.labels.tags
+}
+
 resource "aws_ssm_parameter" "daily_registrations_reporter_email_subject" {
   count     = contains(var.optional_parameters_to_include, "daily_registrations_reporter_email_subject") ? 1 : 0
   overwrite = true

--- a/scripts/create-tf-state-backend.sh
+++ b/scripts/create-tf-state-backend.sh
@@ -40,7 +40,7 @@ aws s3api put-bucket-versioning --bucket ${s3_bucket_name} --versioning-configur
 # Apply block public access config
 aws s3api put-public-access-block \
 	--bucket ${s3_bucket_name} \
-	--public-access-block-configuration "BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true" \
+	--public-access-block-configuration "BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true"
 
 
 # DynamoDb table

--- a/sns.tf
+++ b/sns.tf
@@ -1,6 +1,14 @@
 # #########################################
 # SNS
 # #########################################
+resource "aws_sns_topic" "callback_email_notifications" {
+  count = local.enable_callback_email_notifications_count
+
+  name              = "${module.labels.id}-callback-email-notifications"
+  kms_master_key_id = aws_kms_alias.sns.arn
+  tags              = module.labels.tags
+}
+
 resource "aws_sns_topic" "daily_registrations_reporter" {
   count = local.lambda_daily_registrations_reporter_count
 

--- a/variables.tf
+++ b/variables.tf
@@ -147,28 +147,28 @@ variable "admins_role_require_mfa" {
 # #########################################
 # API & Lambda - Settings & Env vars
 # #########################################
-variable "api_image_repo_url" {
-  description = "ECR image repo to be deployed into ECS for the API container, includes the tag"
+variable "api_custom_image" {
+  description = "Custom image for the ECS API container, overrides the default ECR repo, assumes we can pull from the repository"
   default     = ""
 }
 variable "api_image_tag" {
-  description = "ECR image tag to be deployed into ECS for the API container"
+  description = "Image tag for the ECS API container"
   default     = "latest"
 }
-variable "migrations_image_repo_url" {
-  description = "ECR image repo to be deployed into ECS for the Migration container, includes the tag"
+variable "migrations_custom_image" {
+  description = "Custom image for the ECS Migrations container, overrides the default ECR repo, assumes we can pull from the repository"
   default     = ""
 }
 variable "migrations_image_tag" {
-  description = "ECR image tag to be deployed into ECS for the Migration container"
+  description = "Image tag for the ECS Migrations container"
   default     = "latest"
 }
-variable "push_image_repo_url" {
-  description = "ECR image repo to be deployed into ECS for the Push API container, includes the tag"
+variable "push_custom_image" {
+  description = "Custom image for the ECS Push container, overrides the default ECR repo, assumes we can pull from the repository"
   default     = ""
 }
 variable "push_image_tag" {
-  description = "ECR image tag to be deployed into ECS for the Push API container"
+  description = "Image tag for the ECS Push container"
   default     = "latest"
 }
 variable "api_listening_port" {

--- a/variables.tf
+++ b/variables.tf
@@ -303,6 +303,9 @@ variable "app_bundle_id" {
 variable "enable_callback" {
   default = "true"
 }
+variable "enable_callback_email_notifications" {
+  default = "false"
+}
 variable "enable_check_in" {
   default = "true"
 }
@@ -357,6 +360,9 @@ variable "lambda_exposures_memory_size" {
 variable "lambda_exposures_timeout" {
   default = 15
 }
+variable "lambda_provisioned_concurrencies" {
+  default = {}
+}
 variable "lambda_settings_memory_size" {
   default = 128
 }
@@ -365,9 +371,6 @@ variable "lambda_settings_timeout" {
 }
 variable "lambda_sms_memory_size" {
   default = 128
-}
-variable "lambda_provisioned_concurrencies" {
-  default = {}
 }
 variable "lambda_sms_timeout" {
   default = 15

--- a/variables.tf
+++ b/variables.tf
@@ -327,11 +327,17 @@ variable "default_region" {
 variable "lambda_authorizer_memory_size" {
   default = 512 # Since this is on the hot path and we get faster CPUs with higher memory
 }
+variable "lambda_authorizer_s3_key" {
+  default = ""
+}
 variable "lambda_authorizer_timeout" {
   default = 15
 }
 variable "lambda_callback_memory_size" {
   default = 128
+}
+variable "lambda_callback_s3_key" {
+  default = ""
 }
 variable "lambda_callback_timeout" {
   default = 15
@@ -339,11 +345,17 @@ variable "lambda_callback_timeout" {
 variable "lambda_cso_memory_size" {
   default = 3008
 }
+variable "lambda_cso_s3_key" {
+  default = ""
+}
 variable "lambda_cso_timeout" {
   default = 900
 }
 variable "lambda_daily_registrations_reporter_memory_size" {
   default = 128
+}
+variable "lambda_daily_registrations_reporter_s3_key" {
+  default = ""
 }
 variable "lambda_daily_registrations_reporter_timeout" {
   default = 15
@@ -351,11 +363,17 @@ variable "lambda_daily_registrations_reporter_timeout" {
 variable "lambda_download_memory_size" {
   default = 128
 }
+variable "lambda_download_s3_key" {
+  default = ""
+}
 variable "lambda_download_timeout" {
   default = 15
 }
 variable "lambda_exposures_memory_size" {
   default = 128
+}
+variable "lambda_exposures_s3_key" {
+  default = ""
 }
 variable "lambda_exposures_timeout" {
   default = 15
@@ -366,11 +384,17 @@ variable "lambda_provisioned_concurrencies" {
 variable "lambda_settings_memory_size" {
   default = 128
 }
+variable "lambda_settings_s3_key" {
+  default = ""
+}
 variable "lambda_settings_timeout" {
   default = 15
 }
 variable "lambda_sms_memory_size" {
   default = 128
+}
+variable "lambda_sms_s3_key" {
+  default = ""
 }
 variable "lambda_sms_timeout" {
   default = 15
@@ -378,11 +402,17 @@ variable "lambda_sms_timeout" {
 variable "lambda_stats_memory_size" {
   default = 256
 }
+variable "lambda_stats_s3_key" {
+  default = ""
+}
 variable "lambda_stats_timeout" {
   default = 120
 }
 variable "lambda_token_memory_size" {
   default = 128
+}
+variable "lambda_token_s3_key" {
+  default = ""
 }
 variable "lambda_token_timeout" {
   default = 15
@@ -390,8 +420,15 @@ variable "lambda_token_timeout" {
 variable "lambda_upload_memory_size" {
   default = 128
 }
+variable "lambda_upload_s3_key" {
+  default = ""
+}
 variable "lambda_upload_timeout" {
   default = 15
+}
+variable "lambdas_custom_s3_bucket" {
+  description = "Lambdas custom S3 bucket, overrides the default local file usage, assumes we can get content from the bucket as this module does not manage this bucket"
+  default     = ""
 }
 variable "native_regions" {
   default = ""


### PR DESCRIPTION
- Added: Option to use an S3 bucket as the source for lambdas, will be a global setting and we do not manage this bucket as this is a non default option
- Added: Added option to send callback notifications using email via an SNS topic - subscription will not be automated
- Fixed: Altered the ECS image so the custom vars are just for the image and do not include the tag, we append the tag if using a custom image using the tag var
- Fixed: Fixed the "bastion_amazon_ssm_managed_instance_core" aws_iam_role_policy_attachment (Incorrect casing in name), this will result in a Terraform apply failure when applied, can run a second time to fix
- Fixed: Removed RDS admin user access where not needed
- Added: Added "verify" secret and changed "jwt_issuer" and "certificate_audience" parameters to support third party key server