### PR TITLE
Granted the operators IAM group access to the RDS read_only_user secret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this project will be documented in this file.
 
 
 ## [Unreleased]
-- Added: Now sms lambda can send transactional SMS
+- Added: Allow operators read the rds_readonly_user secret so they can connect to the RDS DB
+- Added: Support for lambdas using transactional SMS
 - Added: Added extra field "LOG_ERROR" = 60 to default "metrics_config" parameter value
 
 ## [v0.1.3] 2020-08-25

--- a/docs/bastion.md
+++ b/docs/bastion.md
@@ -10,9 +10,16 @@ There is a schedule to scale down the bastions at 21:01 UTC each day - so your s
 - You should then be able to see the instance on the AWS console and can select and hit Connect -> Session Manager
 
 
+
 # PostgreSQL client installation
 The postgresql11 package will be installed using cloud-init, but if you need to install can use
 ```sudo amazon-linux-extras install postgresql11```
+
+
+# Connecting to the Database
+See the top of the [doc](./db.md) where it includes info on connecting using the RDS read_only_user
+- The IAM operators group has access to AWS parameters and the AWS secret to allow this
+
 
 
 # NOTES

--- a/docs/db.md
+++ b/docs/db.md
@@ -19,15 +19,15 @@ Database name is in the prefix-db_database parameter
 ./scripts/aws-parameters.sh values dev-xyz-db_database
 ```
 
-Credentials are in the prefix-rds secrets - Will be 3 of them
+Credentials are in the prefix-rds secrets - Will be 3 of them - have used
 ```
-./scripts/aws-secrets.sh values dev-xyz-rds
+./scripts/aws-secrets.sh values dev-xyz-rds-read-only
 ```
 
 ## Connecting
 Connect with
 ```
-psql -h xyz-dev-rds.cluster-something.eu-west-1.rds.amazonaws.com -U rds_admin_user -d xyz
+psql -h xyz-dev-rds.cluster-something.eu-west-1.rds.amazonaws.com -U read_only_user -d xyz
 ```
 
 
@@ -35,7 +35,7 @@ psql -h xyz-dev-rds.cluster-something.eu-west-1.rds.amazonaws.com -U rds_admin_u
 # Extensions configuration
 Need to create the pgcrypto extension as the master user, seems you cannot/should not grant access to creating this to mormal users, see [here](https://dba.stackexchange.com/questions/175319/postgresql-enabling-extensions-without-super-user)
 
-## Connect with
+## Connect with rds_admin_user
 ```
 psql -h xyz-dev-rds.cluster-something.eu-west-1.rds.amazonaws.com -U rds_admin_user -d xyz
 ```

--- a/modules/lambda/main.tf
+++ b/modules/lambda/main.tf
@@ -136,7 +136,7 @@ data "aws_iam_policy_document" "this" {
   dynamic statement {
     for_each = var.enable_sns_publish_for_sms_without_a_topic ? { 1 : 1 } : {}
     content {
-      actions   = [
+      actions = [
         "sns:Publish",
         "sns:SetSMSAttributes",
       ]

--- a/operators.tf
+++ b/operators.tf
@@ -30,6 +30,14 @@ data "aws_iam_policy_document" "operators" {
     effect = "Deny"
   }
 
+  # Allow getting the RDS read_only_user credentials secret
+  statement {
+    actions = [
+      "secretsmanager:GetSecretValue"
+    ]
+    resources = [data.aws_secretsmanager_secret_version.rds_read_only.arn]
+  }
+
   # Conditional
   # PENDING: This works from the CLI without autoscaling:UpdateAutoScalingGroup but we need autoscaling:UpdateAutoScalingGroup to work in the console
   # autoscaling:UpdateAutoScalingGroup is too permissive


### PR DESCRIPTION
See https://github.com/nearform/covid-tracker-infrastructure/issues/266