### PR TITLE
Custom lambda layers option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 
 ## [Unreleased]
+- Added: Default "lambda_default_runtime" variable - nodejs12.x
 - Added: Option to use lambda custom runtimes, see the "lambda_custom_runtimes" variable
 - Added: Ignore filename in lambda lifecycle
 - Added: Added extra parameter "symptom_date_offset" to add an offset in hours to symptomDate or onsetDate in uploads

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 
 ## [Unreleased]
+- Added: Option to use lambda custom runtimes, see the "lambda_custom_runtimes" variable
 - Added: Ignore filename in lambda lifecycle
 - Added: Added extra parameter "symptom_date_offset" to add an offset in hours to symptomDate or onsetDate in uploads
 - Added: Added "api_gateway_account_creation_enabled" variable to control APIGateway account creation as needed for CloudWatch logging, if one already exists you may NOT want to create

--- a/lambda-authorizer.tf
+++ b/lambda-authorizer.tf
@@ -66,9 +66,10 @@ resource "aws_lambda_function" "authorizer" {
 
   function_name = "${module.labels.id}-authorizer"
   handler       = "authorizer.handler"
+  layers        = lookup(var.lambda_custom_runtimes, "authorizer", "NOT-FOUND") == "NOT-FOUND" ? null : var.lambda_custom_runtimes["authorizer"].layers
   memory_size   = var.lambda_authorizer_memory_size
   role          = aws_iam_role.authorizer.arn
-  runtime       = "nodejs12.x"
+  runtime       = lookup(var.lambda_custom_runtimes, "authorizer", "NOT-FOUND") == "NOT-FOUND" ? var.lambda_default_runtime : var.lambda_custom_runtimes["authorizer"].runtime
   tags          = module.labels.tags
   timeout       = var.lambda_authorizer_timeout
 

--- a/lambda-callback.tf
+++ b/lambda-callback.tf
@@ -111,9 +111,10 @@ resource "aws_lambda_function" "callback" {
 
   function_name = "${module.labels.id}-callback"
   handler       = "callback.handler"
+  layers        = lookup(var.lambda_custom_runtimes, "callback", "NOT-FOUND") == "NOT-FOUND" ? null : var.lambda_custom_runtimes["callback"].layers
   memory_size   = var.lambda_callback_memory_size
   role          = aws_iam_role.callback.arn
-  runtime       = "nodejs12.x"
+  runtime       = lookup(var.lambda_custom_runtimes, "callback", "NOT-FOUND") == "NOT-FOUND" ? var.lambda_default_runtime : var.lambda_custom_runtimes["callback"].runtime
   tags          = module.labels.tags
   timeout       = var.lambda_callback_timeout
 

--- a/lambda-cso.tf
+++ b/lambda-cso.tf
@@ -87,9 +87,10 @@ resource "aws_lambda_function" "cso" {
 
   function_name = "${module.labels.id}-cso"
   handler       = "cso.handler"
+  layers        = lookup(var.lambda_custom_runtimes, "cso", "NOT-FOUND") == "NOT-FOUND" ? null : var.lambda_custom_runtimes["cso"]
   memory_size   = var.lambda_cso_memory_size
   role          = aws_iam_role.cso[0].arn
-  runtime       = "nodejs12.x"
+  runtime       = lookup(var.lambda_custom_runtimes, "cso", "NOT-FOUND") == "NOT-FOUND" ? "nodejs12" : "provided"
   tags          = module.labels.tags
   timeout       = var.lambda_cso_timeout
 

--- a/lambda-cso.tf
+++ b/lambda-cso.tf
@@ -91,7 +91,6 @@ resource "aws_lambda_function" "cso" {
   memory_size   = var.lambda_cso_memory_size
   role          = aws_iam_role.cso[0].arn
   runtime       = lookup(var.lambda_custom_runtimes, "cso", "NOT-FOUND") == "NOT-FOUND" ? var.lambda_default_runtime : var.lambda_custom_runtimes["cso"].runtime
-
   tags          = module.labels.tags
   timeout       = var.lambda_cso_timeout
 

--- a/lambda-cso.tf
+++ b/lambda-cso.tf
@@ -87,10 +87,11 @@ resource "aws_lambda_function" "cso" {
 
   function_name = "${module.labels.id}-cso"
   handler       = "cso.handler"
-  layers        = lookup(var.lambda_custom_runtimes, "cso", "NOT-FOUND") == "NOT-FOUND" ? null : var.lambda_custom_runtimes["cso"]
+  layers        = lookup(var.lambda_custom_runtimes, "cso", "NOT-FOUND") == "NOT-FOUND" ? null : var.lambda_custom_runtimes["cso"].layers
   memory_size   = var.lambda_cso_memory_size
   role          = aws_iam_role.cso[0].arn
-  runtime       = lookup(var.lambda_custom_runtimes, "cso", "NOT-FOUND") == "NOT-FOUND" ? "nodejs12" : "provided"
+  runtime       = lookup(var.lambda_custom_runtimes, "cso", "NOT-FOUND") == "NOT-FOUND" ? var.lambda_default_runtime : var.lambda_custom_runtimes["cso"].runtime
+
   tags          = module.labels.tags
   timeout       = var.lambda_cso_timeout
 

--- a/lambda-daily-registrations-reporter.tf
+++ b/lambda-daily-registrations-reporter.tf
@@ -27,8 +27,10 @@ module "daily_registrations_reporter" {
   config_var_prefix              = local.config_var_prefix
   handler                        = "reporter.handler"
   kms_writer_arns                = [aws_kms_key.sns.arn]
+  layers                         = lookup(var.lambda_custom_runtimes, "daily-registrations-reporter", "NOT-FOUND") == "NOT-FOUND" ? null : var.lambda_custom_runtimes["daily-registrations-reporter"].layers
   log_retention_days             = var.logs_retention_days
   memory_size                    = var.lambda_daily_registrations_reporter_memory_size
+  runtime                        = lookup(var.lambda_custom_runtimes, "daily-registrations-reporter", "NOT-FOUND") == "NOT-FOUND" ? var.lambda_default_runtime : var.lambda_custom_runtimes["daily-registrations-reporter"].runtime
   s3_bucket                      = var.lambdas_custom_s3_bucket
   s3_key                         = var.lambda_daily_registrations_reporter_s3_key
   security_group_ids             = [module.lambda_sg.id]

--- a/lambda-download.tf
+++ b/lambda-download.tf
@@ -21,8 +21,10 @@ module "download" {
   cloudwatch_schedule_expression = var.download_schedule
   config_var_prefix              = local.config_var_prefix
   handler                        = "download.handler"
+  layers                         = lookup(var.lambda_custom_runtimes, "download", "NOT-FOUND") == "NOT-FOUND" ? null : var.lambda_custom_runtimes["download"].layers
   log_retention_days             = var.logs_retention_days
   memory_size                    = var.lambda_download_memory_size
+  runtime                        = lookup(var.lambda_custom_runtimes, "download", "NOT-FOUND") == "NOT-FOUND" ? var.lambda_default_runtime : var.lambda_custom_runtimes["download"].runtime
   s3_bucket                      = var.lambdas_custom_s3_bucket
   s3_key                         = var.lambda_download_s3_key
   security_group_ids             = [module.lambda_sg.id]

--- a/lambda-exposures.tf
+++ b/lambda-exposures.tf
@@ -86,9 +86,10 @@ resource "aws_lambda_function" "exposures" {
 
   function_name = "${module.labels.id}-exposures"
   handler       = "exposures.handler"
+  layers        = lookup(var.lambda_custom_runtimes, "exposures", "NOT-FOUND") == "NOT-FOUND" ? null : var.lambda_custom_runtimes["exposures"].layers
   memory_size   = var.lambda_exposures_memory_size
   role          = aws_iam_role.exposures.arn
-  runtime       = "nodejs12.x"
+  runtime       = lookup(var.lambda_custom_runtimes, "exposures", "NOT-FOUND") == "NOT-FOUND" ? var.lambda_default_runtime : var.lambda_custom_runtimes["exposures"].runtime
   tags          = module.labels.tags
   timeout       = var.lambda_exposures_timeout
 

--- a/lambda-settings.tf
+++ b/lambda-settings.tf
@@ -82,9 +82,10 @@ resource "aws_lambda_function" "settings" {
 
   function_name = "${module.labels.id}-settings"
   handler       = "settings.handler"
+  layers        = lookup(var.lambda_custom_runtimes, "settings", "NOT-FOUND") == "NOT-FOUND" ? null : var.lambda_custom_runtimes["settings"].layers
   memory_size   = var.lambda_settings_memory_size
   role          = aws_iam_role.settings.arn
-  runtime       = "nodejs12.x"
+  runtime       = lookup(var.lambda_custom_runtimes, "settings", "NOT-FOUND") == "NOT-FOUND" ? var.lambda_default_runtime : var.lambda_custom_runtimes["settings"].runtime
   tags          = module.labels.tags
   timeout       = var.lambda_settings_timeout
 

--- a/lambda-sms.tf
+++ b/lambda-sms.tf
@@ -28,8 +28,10 @@ module "sms" {
   enable_sns_publish_for_sms_without_a_topic = var.enable_sms_publishing_with_aws
   handler                                    = "sms.handler"
   kms_reader_arns                            = [aws_kms_key.sqs.arn]
+  layers                                     = lookup(var.lambda_custom_runtimes, "sms", "NOT-FOUND") == "NOT-FOUND" ? null : var.lambda_custom_runtimes["sms"].layers
   log_retention_days                         = var.logs_retention_days
   memory_size                                = var.lambda_sms_memory_size
+  runtime                                    = lookup(var.lambda_custom_runtimes, "sms", "NOT-FOUND") == "NOT-FOUND" ? var.lambda_default_runtime : var.lambda_custom_runtimes["sms"].runtime
   s3_bucket                                  = var.lambdas_custom_s3_bucket
   s3_key                                     = var.lambda_sms_s3_key
   security_group_ids                         = [module.lambda_sg.id]

--- a/lambda-stats.tf
+++ b/lambda-stats.tf
@@ -83,9 +83,10 @@ resource "aws_lambda_function" "stats" {
 
   function_name = "${module.labels.id}-stats"
   handler       = "stats.handler"
+  layers        = lookup(var.lambda_custom_runtimes, "stats", "NOT-FOUND") == "NOT-FOUND" ? null : var.lambda_custom_runtimes["stats"]
   memory_size   = var.lambda_stats_memory_size
   role          = aws_iam_role.stats.arn
-  runtime       = "nodejs12.x"
+  runtime       = lookup(var.lambda_custom_runtimes, "stats", "NOT-FOUND") == "NOT-FOUND" ? "nodejs12" : "provided"
   tags          = module.labels.tags
   timeout       = var.lambda_stats_timeout
 

--- a/lambda-stats.tf
+++ b/lambda-stats.tf
@@ -83,10 +83,10 @@ resource "aws_lambda_function" "stats" {
 
   function_name = "${module.labels.id}-stats"
   handler       = "stats.handler"
-  layers        = lookup(var.lambda_custom_runtimes, "stats", "NOT-FOUND") == "NOT-FOUND" ? null : var.lambda_custom_runtimes["stats"]
+  layers        = lookup(var.lambda_custom_runtimes, "stats", "NOT-FOUND") == "NOT-FOUND" ? null : var.lambda_custom_runtimes["stats"].layers
   memory_size   = var.lambda_stats_memory_size
   role          = aws_iam_role.stats.arn
-  runtime       = lookup(var.lambda_custom_runtimes, "stats", "NOT-FOUND") == "NOT-FOUND" ? "nodejs12" : "provided"
+  runtime       = lookup(var.lambda_custom_runtimes, "stats", "NOT-FOUND") == "NOT-FOUND" ? var.lambda_default_runtime : var.lambda_custom_runtimes["stats"].runtime
   tags          = module.labels.tags
   timeout       = var.lambda_stats_timeout
 

--- a/lambda-token.tf
+++ b/lambda-token.tf
@@ -80,9 +80,10 @@ resource "aws_lambda_function" "token" {
 
   function_name = "${module.labels.id}-token"
   handler       = "token.handler"
+  layers        = lookup(var.lambda_custom_runtimes, "token", "NOT-FOUND") == "NOT-FOUND" ? null : var.lambda_custom_runtimes["token"].layers
   memory_size   = var.lambda_token_memory_size
   role          = aws_iam_role.token.arn
-  runtime       = "nodejs12.x"
+  runtime       = lookup(var.lambda_custom_runtimes, "token", "NOT-FOUND") == "NOT-FOUND" ? var.lambda_default_runtime : var.lambda_custom_runtimes["token"].runtime
   tags          = module.labels.tags
   timeout       = var.lambda_token_timeout
 

--- a/lambda-upload.tf
+++ b/lambda-upload.tf
@@ -21,8 +21,10 @@ module "upload" {
   cloudwatch_schedule_expression = var.upload_schedule
   config_var_prefix              = local.config_var_prefix
   handler                        = "upload.handler"
+  layers                         = lookup(var.lambda_custom_runtimes, "upload", "NOT-FOUND") == "NOT-FOUND" ? null : var.lambda_custom_runtimes["upload"].layers
   log_retention_days             = var.logs_retention_days
   memory_size                    = var.lambda_upload_memory_size
+  runtime                        = lookup(var.lambda_custom_runtimes, "upload", "NOT-FOUND") == "NOT-FOUND" ? var.lambda_default_runtime : var.lambda_custom_runtimes["upload"].runtime
   s3_bucket                      = var.lambdas_custom_s3_bucket
   s3_key                         = var.lambda_upload_s3_key
   security_group_ids             = [module.lambda_sg.id]

--- a/modules/lambda/main.tf
+++ b/modules/lambda/main.tf
@@ -47,6 +47,11 @@ variable "kms_writer_arns" {
   default = []
 }
 
+# If using a custom runtime i.e. runtime = "provided", set this to a list of layers
+variable "layers" {
+  default = null
+}
+
 variable "log_retention_days" {
   default = 1
 }
@@ -284,6 +289,7 @@ resource "aws_lambda_function" "this" {
 
   function_name = var.name
   handler       = var.handler
+  layers        = var.layers
   memory_size   = var.memory_size
   role          = aws_iam_role.this[0].arn
   runtime       = var.runtime

--- a/variables.tf
+++ b/variables.tf
@@ -439,7 +439,7 @@ variable "lambda_callback_timeout" {
   default     = 15
 }
 variable "lambda_custom_runtimes" {
-  description = "Map of lambdas to use custom runtimes, where the value is the layers to use i.e. { \"authorizer\" : [\"some-arn\"] }"
+  description = "Map of lambdas to use custom runtimes, where the value is an object with the runtime and layers to use i.e. { \"authorizer\" : { \"runtime\": \"provided\", \"layers\": [\"some-arn\"] } }"
   default     = {}
 }
 variable "lambda_cso_memory_size" {
@@ -465,6 +465,10 @@ variable "lambda_daily_registrations_reporter_s3_key" {
 variable "lambda_daily_registrations_reporter_timeout" {
   description = "daily-registrations-reporter lambda timeout"
   default     = 15
+}
+variable "lambda_default_runtime" {
+  description = "Default lambda runtime"
+  default     = "nodejs12.x"
 }
 variable "lambda_download_memory_size" {
   description = "download lambda memory size"

--- a/variables.tf
+++ b/variables.tf
@@ -438,6 +438,10 @@ variable "lambda_callback_timeout" {
   description = "callback lambda timeout"
   default     = 15
 }
+variable "lambda_custom_runtimes" {
+  description = "Map of lambdas to use custom runtimes, where the value is the layers to use i.e. { \"authorizer\" : [\"some-arn\"] }"
+  default     = {}
+}
 variable "lambda_cso_memory_size" {
   description = "cso lambda memory size"
   default     = 3008


### PR DESCRIPTION
See https://github.com/nearform/covid-tracker-infrastructure/issues/300

Allow using custom runtimes for the lambdas