### PR TITLE
Relax TF version requirement so we can use v0.13.*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 
 ## [Unreleased]
+- Updated: Alter terraform version requirement so we can start using v0.13.*, we now have >= 0.12.29 < 0.14
 - Added: Enabled encryption on the CloudTrail and assets S3 buckets
 
 

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@
 # Backend config
 # #########################################
 terraform {
-  required_version = ">= 0.12.29"
+  required_version = ">= 0.12.29, < 0.14"
 
   # Leaving this, even though we have moved towards using this repo as a module - will ignore in that case
   # Also need to cater for git submodule/subtree usage for existing infrastructure


### PR DESCRIPTION
See https://github.com/nearform/covid-tracker-infrastructure/issues/244

We are not altering the aws provider yet due to the RDS module we use having a restriction