### PR TITLE
Update TF module versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 
 ## [Unreleased]
+- Updated: Module versions, needed to ensure they result in no changes
+	- alb.tf - Went with v8.2.0, cannot use latest as it requires AWS provider v3+ and TF v0.13+
+	- labels.tf - Went with v0.19.2, is the latest at this time
+	- networking.tf	- Went with v2.48.0, is the latest at this time
+	- rds.tf - Went with v0.31.0, cannot use latest, as it results in changes
 - Fix: Parameter "upload_token_lifetime_mins" was using the wrong variable value
 - Updated: Operators role can manage their MFA
 - Added: extra properties to configure SNS SMS preferences

--- a/alb.tf
+++ b/alb.tf
@@ -176,7 +176,7 @@ resource "aws_lb_listener" "push_https" {
 # #########################################
 module "alb_logs" {
   source  = "trussworks/logs/aws"
-  version = "8.1.0"
+  version = "8.2.0"
 
   alb_logs_prefixes       = ["api", "push"]
   allow_alb               = true

--- a/labels.tf
+++ b/labels.tf
@@ -3,7 +3,7 @@
 # #########################################
 module "labels" {
   source  = "cloudposse/label/null"
-  version = "0.16.0"
+  version = "0.19.2"
   name    = var.namespace
   stage   = var.environment
 

--- a/main.tf
+++ b/main.tf
@@ -1,23 +1,4 @@
 # #########################################
-# Backend config
-# #########################################
-terraform {
-  required_version = ">= 0.12.29, < 0.14"
-
-  # Leaving this, even though we have moved towards using this repo as a module - will ignore in that case
-  # Also need to cater for git submodule/subtree usage for existing infrastructure
-  backend "s3" {}
-
-  # Providers
-  required_providers {
-    archive = "~> 1.3.0"
-    aws     = "~> 2.70"
-    null    = "~> 2.1"
-    random  = "~> 2.0"
-  }
-}
-
-# #########################################
 # AWS providers
 # #########################################
 # Main provider

--- a/networking.tf
+++ b/networking.tf
@@ -4,7 +4,7 @@
 # #########################################
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "2.44.0"
+  version = "2.48.0"
 
   name = module.labels.id
   cidr = var.vpc_cidr

--- a/operators.tf
+++ b/operators.tf
@@ -37,18 +37,16 @@ data "aws_iam_policy_document" "operators" {
     ]
     resources = [data.aws_secretsmanager_secret_version.rds_read_only.arn]
   }
-  
+
   # Allow own MFA management
-  
+
   statement {
-    sid    = "MFAPersonalCreate"
-    
+    sid = "MFAPersonalCreate"
     actions = [
       "iam:CreateVirtualMFADevice",
       "iam:DeleteVirtualMFADevice"
     ]
     resources = [format("arn:aws:iam::%s:mfa/&{aws:username}", data.aws_caller_identity.current.account_id)]
-    
   }
 
   # Conditional

--- a/rds.tf
+++ b/rds.tf
@@ -32,7 +32,7 @@ resource "aws_iam_role_policy_attachment" "rds_enhanced_monitoring" {
 
 module "rds_cluster_aurora_postgres" {
   source              = "cloudposse/rds-cluster/aws"
-  version             = "0.27.0"
+  version             = "0.31.0"
   engine              = "aurora-postgresql"
   cluster_family      = var.rds_cluster_family
   cluster_size        = var.rds_cluster_size

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_version = ">= 0.12.29, < 0.14"
+
+  # Leaving this, even though we have moved towards using this repo as a module - will ignore in that case
+  # Also need to cater for git submodule/subtree usage for existing infrastructure
+  backend "s3" {}
+
+  # Providers
+  required_providers {
+    archive = "~> 1.3.0"
+    aws     = "~> 2.70"
+    null    = "~> 2.1"
+    random  = "~> 2.0"
+  }
+}


### PR DESCRIPTION
Needed to look into the modules due to the Global Accelerator requirement for some tenants, there is an issue that is resolved on the AWS provider version v3.5+

Have updated these modules to the point where they do not result in changes - have tested this in dev, qa and prod instances with a plan that indicates no changes are needed

The RDS module is going to be the problem, this is not addressed here


| File | Module   | Version | Notes |
| ----- | ----------- | -----------| ---------|
| alb.tf               | https://github.com/trussworks/terraform-aws-logs                    | v8.2.0                           | Cannot use latest as it requires AWS provider v3+, TF v0.13+, this version results in no changes |
| labels.tf	         | https://github.com/cloudposse/terraform-null-label                           | v0.19.2                          | Is the latest at this time, this version results in no changes |
| networking.tf   | https://github.com/terraform-aws-modules/terraform-aws-vpc | v2.48.0                          | Is the latest at this time, this version results in no changes |
| rds.tf               | https://github.com/cloudposse/terraform-aws-rds-cluster         | v0.31.0                          | Cannot use latest, as it results in changes, this version does not allow AWS provider v3, this version results in no changes |
