### PR TITLE
Added easy improvements from NYS customization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 
 ## [Unreleased]
+- Added: New "api_gateway_minimum_compression_size" to allow compression configuration on the APIGateway
+- Added: New variables to control ECS scaling adjustments
+	- api_ecs_autoscale_scale_down_adjustment
+	- api_ecs_autoscale_scale_up_adjustment
+	- push_ecs_autoscale_scale_down_adjustment
+	- push_ecs_autoscale_scale_up_adjustment
 
 
 ## [v0.1.7] 2020-09-17
@@ -16,7 +22,7 @@ All notable changes to this project will be documented in this file.
 - Added: Added "db_pool_size" variable to control pg max pool size - Can be used by ECS API and ECS Push services
 - Updated: Allow stats lambda to access "time_zone" parameter
 - Updated: Added additional resources to the operators group policy for MFA
-- Fix: Adjusted values displayed in the CloudWatch dashboard, so take into consideration doubled logs in ApiGateway logs 
+- Fix: Adjusted values displayed in the CloudWatch dashboard, so take into consideration doubled logs in ApiGateway logs
 
 
 ## [v0.1.6] 2020-09-10

--- a/ecs_api.tf
+++ b/ecs_api.tf
@@ -155,16 +155,18 @@ resource "aws_ecs_service" "api" {
 }
 
 module "api_autoscale" {
-  source                      = "./modules/ecs-autoscale-service"
-  ecs_cluster_resource_name   = aws_ecs_cluster.services.name
-  service_resource_name       = aws_ecs_service.api.name
-  ecs_autoscale_max_instances = var.api_ecs_autoscale_max_instances
-  ecs_autoscale_min_instances = var.api_ecs_autoscale_min_instances
-  ecs_as_cpu_high_threshold   = var.api_cpu_high_threshold
-  ecs_as_cpu_low_threshold    = var.api_cpu_low_threshold
-  ecs_as_mem_high_threshold   = var.api_mem_high_threshold
-  ecs_as_mem_low_threshold    = var.api_mem_low_threshold
-  tags                        = module.labels.tags
+  source                              = "./modules/ecs-autoscale-service"
+  ecs_cluster_resource_name           = aws_ecs_cluster.services.name
+  service_resource_name               = aws_ecs_service.api.name
+  ecs_autoscale_max_instances         = var.api_ecs_autoscale_max_instances
+  ecs_autoscale_min_instances         = var.api_ecs_autoscale_min_instances
+  ecs_autoscale_scale_down_adjustment = var.api_ecs_autoscale_scale_down_adjustment
+  ecs_autoscale_scale_up_adjustment   = var.api_ecs_autoscale_scale_up_adjustment
+  ecs_as_cpu_high_threshold           = var.api_cpu_high_threshold
+  ecs_as_cpu_low_threshold            = var.api_cpu_low_threshold
+  ecs_as_mem_high_threshold           = var.api_mem_high_threshold
+  ecs_as_mem_low_threshold            = var.api_mem_low_threshold
+  tags                                = module.labels.tags
 }
 
 # #########################################

--- a/ecs_push.tf
+++ b/ecs_push.tf
@@ -139,16 +139,18 @@ resource "aws_ecs_service" "push" {
 }
 
 module "push_autoscale" {
-  source                      = "./modules/ecs-autoscale-service"
-  ecs_cluster_resource_name   = aws_ecs_cluster.services.name
-  service_resource_name       = aws_ecs_service.push.name
-  ecs_autoscale_max_instances = var.push_ecs_autoscale_max_instances
-  ecs_autoscale_min_instances = var.push_ecs_autoscale_min_instances
-  ecs_as_cpu_high_threshold   = var.push_cpu_high_threshold
-  ecs_as_cpu_low_threshold    = var.push_cpu_low_threshold
-  ecs_as_mem_high_threshold   = var.push_mem_high_threshold
-  ecs_as_mem_low_threshold    = var.push_mem_low_threshold
-  tags                        = module.labels.tags
+  source                              = "./modules/ecs-autoscale-service"
+  ecs_cluster_resource_name           = aws_ecs_cluster.services.name
+  service_resource_name               = aws_ecs_service.push.name
+  ecs_autoscale_max_instances         = var.push_ecs_autoscale_max_instances
+  ecs_autoscale_min_instances         = var.push_ecs_autoscale_min_instances
+  ecs_autoscale_scale_down_adjustment = var.push_ecs_autoscale_scale_down_adjustment
+  ecs_autoscale_scale_up_adjustment   = var.push_ecs_autoscale_scale_up_adjustment
+  ecs_as_cpu_high_threshold           = var.push_cpu_high_threshold
+  ecs_as_cpu_low_threshold            = var.push_cpu_low_threshold
+  ecs_as_mem_high_threshold           = var.push_mem_high_threshold
+  ecs_as_mem_low_threshold            = var.push_mem_low_threshold
+  tags                                = module.labels.tags
 }
 
 # #########################################

--- a/gateway.tf
+++ b/gateway.tf
@@ -2,8 +2,9 @@
 # API Gateway REST API
 # #########################################
 resource "aws_api_gateway_rest_api" "main" {
-  name = "${module.labels.id}-gw"
-  tags = module.labels.tags
+  name                     = "${module.labels.id}-gw"
+  minimum_compression_size = var.api_gateway_minimum_compression_size
+  tags                     = module.labels.tags
 
   binary_media_types = [
     "application/zip",

--- a/modules/ecs-autoscale-service/main.tf
+++ b/modules/ecs-autoscale-service/main.tf
@@ -21,6 +21,14 @@ variable "ecs_autoscale_min_instances" {
   default = 1
 }
 
+variable "ecs_autoscale_scale_down_adjustment" {
+  default = -1
+}
+
+variable "ecs_autoscale_scale_up_adjustment" {
+  default = 1
+}
+
 variable "ecs_as_cpu_high_threshold" {
   default = 60
 }
@@ -70,7 +78,7 @@ resource "aws_appautoscaling_policy" "scale_up" {
 
     step_adjustment {
       metric_interval_lower_bound = 0
-      scaling_adjustment          = 1
+      scaling_adjustment          = var.ecs_autoscale_scale_up_adjustment
     }
   }
 }
@@ -89,7 +97,7 @@ resource "aws_appautoscaling_policy" "scale_down" {
 
     step_adjustment {
       metric_interval_upper_bound = 0
-      scaling_adjustment          = -1
+      scaling_adjustment          = var.ecs_autoscale_scale_down_adjustment
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -37,6 +37,10 @@ variable "api_gateway_account_creation_enabled" {
   description = "APIGateway account creation flag, this is used for CloudWatch logging, should only have one of these per account/region, this flag allows disabling if one already exists"
   default     = true
 }
+variable "api_gateway_minimum_compression_size" {
+  description = "APIGateway minimum response size to compress for the REST API. Integer between -1 and 10485760 (10MB). Setting a value greater than -1 will enable compression, -1 disables compression (default)"
+  default     = -1
+}
 variable "api_gateway_throttling_burst_limit" {
   description = "APIGateway throttling burst limit, default is -1 which does not enforce a limit"
   default     = -1
@@ -223,6 +227,14 @@ variable "api_ecs_autoscale_max_instances" {
 }
 variable "api_ecs_autoscale_min_instances" {
   description = "ECS API service ASG min count"
+  default     = 1
+}
+variable "api_ecs_autoscale_scale_down_adjustment" {
+  description = "ECS API service ASG scaling scale down adjustment"
+  default     = -1
+}
+variable "api_ecs_autoscale_scale_up_adjustment" {
+  description = "ECS API service ASG scaling scale up adjustment"
   default     = 1
 }
 variable "api_image_tag" {
@@ -571,6 +583,14 @@ variable "push_ecs_autoscale_max_instances" {
 }
 variable "push_ecs_autoscale_min_instances" {
   description = "ECS Push service ASG min count"
+  default     = 1
+}
+variable "push_ecs_autoscale_scale_down_adjustment" {
+  description = "ECS Push service ASG scaling scale down adjustment"
+  default     = -1
+}
+variable "push_ecs_autoscale_scale_up_adjustment" {
+  description = "ECS Push service ASG scaling scale up adjustment"
   default     = 1
 }
 variable "push_image_tag" {


### PR DESCRIPTION
See https://github.com/nearform/covid-tracker-infrastructure/issues/345

**These are the easy ones**
- Added: New "api_gateway_minimum_compression_size" to allow compression configuration on the APIGateway
- Added: New variables to control ECS scaling adjustments
	- api_ecs_autoscale_scale_down_adjustment
	- api_ecs_autoscale_scale_up_adjustment
	- push_ecs_autoscale_scale_down_adjustment
	- push_ecs_autoscale_scale_up_adjustment

Have did a plan to check that this is a no-op against one of our instances and it is as expected
- The usual APIGateway changes as the file has changed