### PR TITLE
Add container insights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ##  Unreleased
+- Added: clouwatch container insights activation option
 - Added: "api_gateway_timeout_milliseconds" variable to control the API Gateway
 
 ## [v0.1.9] 2020-09-29

--- a/ecs.tf
+++ b/ecs.tf
@@ -3,4 +3,10 @@
 # #########################################
 resource "aws_ecs_cluster" "services" {
   name = module.labels.id
+  tags = module.labels.tags
+
+  setting {
+    name = "containerInsights"
+    value = var.enable_ecs_container_insights ? "enabled" : "disabled"
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -102,6 +102,14 @@ variable "push_eu_certificate_arn" {
 }
 
 # #########################################
+# ECS Cluster Settings
+# #########################################
+variable "enable_ecs_container_insights" {
+  description = "Enable or disable Cloudwatch Container insights for the ECS cluster"
+  default     = false
+}
+
+# #########################################
 # ECR Settings
 # #########################################
 variable "default_ecr_max_image_count" {


### PR DESCRIPTION
Add flag to activate/deactivate [CloudWatch Container Insights](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/cloudwatch-container-insights.html) 

A live example can be viewed on tenant [`nfcs-dev`](https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#container-insights:performance/ECS:Cluster?~(query~(controls~(CW*3a*3aECS.cluster~(~'dev-nfcs)))~context~())), it is possible to break down metrics for cluster, service, and task.

Unfortunately, we have no visibility on container exit codes/reasons.