### PR TITLE
Altered some of the lamba timeout variables default value to 180s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ##  Unreleased
+- Updated: "lambda_exposures_timeout" variable default to 180s as we have observed current 30s is insufficent for many tenants
 - Added: "cso_schedule" variable to control the cso lambda schedule
 - Deleted: ci-user security access key credentials, so they are not included in the statefile and output
 - Added: CloudWatch container insights activation option - default is disabled

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
-##  Unreleased
+## Unreleased
+
+
+## [v0.1.10] 2020-10-07
 - Updated: "lambda_callback_timeout" variable default to 180s as we have observed current 15s is insufficent for many tenants
 - Updated: "lambda_exposures_timeout" variable default to 180s as we have observed current 60s is insufficent for many tenants
 - Updated: "lambda_sms_timeout" variable default to 180s as we have observed current 15s is insufficent for many tenants
@@ -10,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - Deleted: ci-user security access key credentials, so they are not included in the statefile and output
 - Added: CloudWatch container insights activation option - default is disabled
 - Added: "api_gateway_timeout_milliseconds" variable to control the API Gateway
+
 
 ## [v0.1.9] 2020-09-29
 - Removed: Cloudwatch dashboard

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 All notable changes to this project will be documented in this file.
 
 ##  Unreleased
-- Updated: "lambda_exposures_timeout" variable default to 180s as we have observed current 30s is insufficent for many tenants
+- Updated: "lambda_callback_timeout" variable default to 180s as we have observed current 15s is insufficent for many tenants
+- Updated: "lambda_exposures_timeout" variable default to 180s as we have observed current 60s is insufficent for many tenants
+- Updated: "lambda_sms_timeout" variable default to 180s as we have observed current 15s is insufficent for many tenants
 - Added: "cso_schedule" variable to control the cso lambda schedule
 - Deleted: ci-user security access key credentials, so they are not included in the statefile and output
 - Added: CloudWatch container insights activation option - default is disabled

--- a/variables.tf
+++ b/variables.tf
@@ -434,7 +434,7 @@ variable "lambda_callback_s3_key" {
 }
 variable "lambda_callback_timeout" {
   description = "callback lambda timeout"
-  default     = 15
+  default     = 180
 }
 variable "lambda_custom_runtimes" {
   description = "Map of lambdas to use custom runtimes, where the value is an object with the runtime and layers to use i.e. { \"authorizer\" : { \"runtime\": \"provided\", \"layers\": [\"some-arn\"] } }"
@@ -530,7 +530,7 @@ variable "lambda_sms_s3_key" {
 }
 variable "lambda_sms_timeout" {
   description = "sms lambda timeout"
-  default     = 15
+  default     = 180
 }
 variable "lambda_stats_memory_size" {
   description = "stats lambda memory size"

--- a/variables.tf
+++ b/variables.tf
@@ -502,7 +502,7 @@ variable "lambda_exposures_s3_key" {
 }
 variable "lambda_exposures_timeout" {
   description = "exposures lambda timeout"
-  default     = 60
+  default     = 180
 }
 variable "lambda_provisioned_concurrencies" {
   description = "Map of lambdas to use provisioned concurrency i.e. { \"authorizer\" : 300 }"


### PR DESCRIPTION
Have observed current values are insufficient for many tenants
- callback 15s -> 180s
- exposures 60s -> 180s
- sms 15s -> 180s