### PR TITLE
Add ses to lambda policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 
 ## Unreleased
+- Added: Lambda policy option to allow sending SES emails based on a from whitelist
 - Added: Lambda options to manage S3 access content in the policy
 - Updated: Restricted ci-user permissions
 

--- a/modules/lambda/main.tf
+++ b/modules/lambda/main.tf
@@ -216,6 +216,7 @@ data "aws_iam_policy_document" "this" {
     }
   }
 
+  # See https://docs.aws.amazon.com/IAM/latest/UserGuide/list_amazonses.html
   # See https://docs.aws.amazon.com/ses/latest/DeveloperGuide/control-user-access.html
   dynamic statement {
     for_each = length(var.ses_send_emails_from_email_addresses) > 0 ? { 1 : 1 } : {}

--- a/modules/lambda/main.tf
+++ b/modules/lambda/main.tf
@@ -89,6 +89,10 @@ variable "s3_key" {
   default = ""
 }
 
+variable "ses_send_emails_from_email_addresses" {
+  default = []
+}
+
 variable "sns_topic_arns_to_consume_from" {
   default = []
 }
@@ -209,6 +213,20 @@ data "aws_iam_policy_document" "this" {
     content {
       actions   = ["secretsmanager:GetSecretValue"]
       resources = var.aws_secret_arns
+    }
+  }
+
+  # See https://docs.aws.amazon.com/ses/latest/DeveloperGuide/control-user-access.html
+  dynamic statement {
+    for_each = length(var.ses_send_emails_from_email_addresses) > 0 ? { 1 : 1 } : {}
+    content {
+      actions   = ["ses:SendEmail", "ses:SendRawEmail"]
+      resources = "*"
+      condition = {
+        test     = "StringLike"
+        variable = "ses:FromAddress"
+        values   = var.ses_send_emails_from_email_addresses
+      }
     }
   }
 

--- a/modules/lambda/main.tf
+++ b/modules/lambda/main.tf
@@ -220,13 +220,13 @@ data "aws_iam_policy_document" "this" {
   dynamic statement {
     for_each = length(var.ses_send_emails_from_email_addresses) > 0 ? { 1 : 1 } : {}
     content {
-      actions   = ["ses:SendEmail", "ses:SendRawEmail"]
-      resources = "*"
-      condition = {
+      actions = ["ses:SendEmail", "ses:SendRawEmail"]
+      condition {
         test     = "StringLike"
-        variable = "ses:FromAddress"
         values   = var.ses_send_emails_from_email_addresses
+        variable = "ses:FromAddress"
       }
+      resources = "*"
     }
   }
 

--- a/modules/lambda/main.tf
+++ b/modules/lambda/main.tf
@@ -226,7 +226,7 @@ data "aws_iam_policy_document" "this" {
         values   = var.ses_send_emails_from_email_addresses
         variable = "ses:FromAddress"
       }
-      resources = "*"
+      resources = ["*"]
     }
   }
 


### PR DESCRIPTION
So we can send emails using AWS SES as required by the new QR functionality