### PR TITLE
Self isolation notices common infra (parameters)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 
 ## Unreleased
-
+- Added: Added parameters enable_self_isolation_notices and self_isolation_notices_url to allow notifying users of self-isolation in some tenants.
 
 ## [v0.1.12] 2020-10-28
 - Updated: Set queue visibility timeout based on lambda timeout

--- a/self-isolation-notices-common.tf
+++ b/self-isolation-notices-common.tf
@@ -1,0 +1,11 @@
+resource "aws_ssm_parameter" "enable_self_isolation_notices" {
+  name  = "${module.labels.id}-enable_self_isolation_notices"
+  type  = "String"
+  value = var.self_isolation_notices_enabled
+}
+
+resource "aws_ssm_parameter" "self_isolation_notices_url" {
+  name  = "${module.labels.id}-self_isolation_notices_url"
+  type  = "String"
+  value = var.self_isolation_notices_url
+}

--- a/variables.tf
+++ b/variables.tf
@@ -744,3 +744,13 @@ variable "variance_offset_mins" {
 variable "verify_rate_limit_secs" {
   description = "Time in seconds a user must wait before attempting to verify a one-time upload code"
 }
+
+variable "self_isolation_notices_enabled" {
+  description = "Flag (string, required by SSM) to enable/disable self-isolation notices"
+  default     = "false"
+}
+
+variable "self_isolation_notices_url" {
+  description = "Self isolation notices target url. Empty by default, conditioned by self_isolation_notices_enabled"
+  default     = "NA"
+}


### PR DESCRIPTION
This infra is common to all the tenants (for now) as the code for self-isolation will be deployed regardless of the functionality being enabled.