### PR TITLE
Add new optional secret for quicksight dashboard

### DIFF
--- a/ecs_admin.tf
+++ b/ecs_admin.tf
@@ -53,12 +53,12 @@ data "aws_iam_policy_document" "admin_ecs_task_policy" {
 
   statement {
     actions = ["secretsmanager:GetSecretValue"]
-    resources = [
+    resources = concat([
       data.aws_secretsmanager_secret_version.rds_read_only.arn,
       data.aws_secretsmanager_secret_version.rds_read_write.arn,
       data.aws_secretsmanager_secret_version.admin_push_service_token.arn,
-      data.aws_secretsmanager_secret_version.google_maps_api_key.arn
-    ]
+      data.aws_secretsmanager_secret_version.google_maps_api_key.arn,      
+    ], data.aws_secretsmanager_secret_version.quicksight_dashboard.*.arn)
   }
   statement {
     actions = [

--- a/secrets.tf
+++ b/secrets.tf
@@ -58,6 +58,11 @@ data "aws_secretsmanager_secret_version" "notice" {
   secret_id = format("%snotice", local.config_var_prefix)
 }
 
+data "aws_secretsmanager_secret_version" "quicksight_dashboard" {
+  count     = contains(var.optional_secrets_to_include, "quicksight-dashboard") ? 1 : 0
+  secret_id = format("%squicksight-dashboard", local.config_var_prefix)
+}
+
 data "aws_secretsmanager_secret_version" "cct" {
   count     = contains(var.optional_secrets_to_include, "cct") ? 1 : 0
   secret_id = "${local.config_var_prefix}cct"


### PR DESCRIPTION
### Issue
nearform/covid-tracker-infrastructure#408

### Description
To support QuickSight functionality an optional secret must be accessible to the admin ecs task