### PR TITLE
Removes Route53 root record

### DIFF
--- a/cognito.tf
+++ b/cognito.tf
@@ -19,16 +19,6 @@ resource "aws_cognito_user_pool_domain" "main" {
   certificate_arn = aws_acm_certificate.wildcard_cert_us[0].arn
 }
 
-### This  is needed by cognito to add domain informations
-resource "aws_route53_record" "root_record" {
-  provider = aws.dns
-  name     = var.route53_zone
-  type     = "A"
-  zone_id  = data.aws_route53_zone.primary[0].id
-  records  = ["1.1.1.1"]
-  ttl      = 300
-}
-
 resource "aws_route53_record" "auth_cognito_A_record" {
   provider = aws.dns
   name     = aws_cognito_user_pool_domain.main.domain

--- a/docs/admin.md
+++ b/docs/admin.md
@@ -1,0 +1,9 @@
+# Admin Web App
+
+## Requirements
+
+### DNS Root Record for Cognito
+
+In order to configure cognito, a DNS Root `A` record **must** be set on domain's DNS table. 
+
+Any target will work, even a fake IP address, Cognito must see that this record is just _present_.


### PR DESCRIPTION
This record is required by Cognito, but conflicts with many tenants.
We should assume the record is already in DNS table, docs are updated.